### PR TITLE
docs: establish public foundation and operating policies

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,6 +13,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Dependency review
-        uses: actions/dependency-review-action@v4
+      - name: Detect dependency manifests
+        id: detect
+        run: |
+          if find . \
+            \( -name 'pnpm-lock.yaml' -o -name 'package-lock.json' -o -name 'yarn.lock' -o -name 'bun.lockb' -o -name 'go.mod' -o -name 'Cargo.lock' -o -name 'poetry.lock' -o -name 'requirements*.txt' \) \
+            -not -path './.git/*' \
+            | grep -q .; then
+            echo "has_manifests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_manifests=false" >> "$GITHUB_OUTPUT"
+          fi
 
+      - name: Skip until manifests exist
+        if: steps.detect.outputs.has_manifests != 'true'
+        run: echo "No dependency manifests are present yet; dependency review is deferred."
+
+      - name: Dependency review
+        if: steps.detect.outputs.has_manifests == 'true'
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   secret-scan:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,4 +22,3 @@ jobs:
 
       - name: Gitleaks scan
         uses: gitleaks/gitleaks-action@v2
-

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,60 @@
+Escalona Labs Public Source License 1.0
+
+Copyright (c) 2026 Escalona Labs. All rights reserved.
+
+This repository is publicly visible for inspection, evaluation, collaboration review,
+and other non-commercial uses expressly allowed by this license.
+
+1. Permitted use
+
+You may:
+
+- view, clone, and download this repository;
+- run, study, and modify the software for personal, educational, research, security,
+  or internal evaluation purposes; and
+- submit issues, pull requests, or patches back to Escalona Labs.
+
+2. Commercial use is prohibited
+
+Without prior written permission from Escalona Labs, you may not, directly or indirectly:
+
+- use the software or any substantial portion of it for commercial purposes;
+- sell, license, sublicense, rent, lease, distribute, or monetize the software;
+- provide the software as a hosted service, managed service, or embedded product;
+- use the software to operate or support a commercial offering;
+- remove, alter, or obscure copyright, trademark, or license notices; or
+- represent this software or any derivative work as an official Escalona Labs product.
+
+3. Trademark and branding restrictions
+
+This license does not grant any right to use the names "Escalona Labs", "Agents Company",
+any Escalona Labs logo, or other Escalona Labs marks except for truthful attribution.
+
+4. No patent or trademark grant
+
+No patent rights, trademark rights, or other intellectual property rights are granted
+except for the limited copyright permission stated above.
+
+5. Contributions
+
+Unless otherwise agreed in writing, any contribution intentionally submitted for inclusion
+in this repository grants Escalona Labs a perpetual, worldwide, non-exclusive, royalty-free,
+irrevocable license to use, reproduce, modify, distribute, and relicense that contribution.
+
+6. Termination
+
+Any use that violates this license automatically terminates the permissions granted above.
+Upon termination, you must stop using and distributing the software and destroy copies that
+are not required to be retained by law.
+
+7. Warranty disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, TITLE, AND NON-INFRINGEMENT.
+
+8. Limitation of liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, ESCALONA LABS SHALL NOT BE LIABLE FOR ANY CLAIM,
+DAMAGES, OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF,
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ pnpm check:repo
 ## Security
 
 See [SECURITY.md](SECURITY.md) for reporting guidance.
+
+## License
+
+This repository is public source-available code under the `Escalona Labs Public Source License 1.0`.
+
+- Commercial use is prohibited without prior written permission from Escalona Labs
+- Repository visibility does not grant product, trademark, or hosting rights
+- See [LICENSE](LICENSE) and [docs/operations/licensing-and-commercial-use.md](docs/operations/licensing-and-commercial-use.md)

--- a/docs/backlog/github-operating-system.md
+++ b/docs/backlog/github-operating-system.md
@@ -8,6 +8,34 @@
 - Incomplete work returns to GitHub with status and blockers recorded
 - No work item is considered done from chat alone
 
+## Lifecycle
+
+### Intake
+
+- work enters through an issue, epic, or documented decision
+- every issue must carry milestone, labels, and validation intent
+
+### Ready
+
+- `state:ready` means a bounded slice can be executed without hidden decisions
+- subagents should only pick work that is actually ready
+
+### Blocked
+
+- `state:blocked` means progress depends on an external action, irreversible decision, or missing prerequisite
+- the blocking reason must be written into the issue
+
+### In progress
+
+- active work is represented by comments, linked pull requests, drafts, checks, or explicit assignment
+- chat alone does not count as in-progress state
+
+### Complete
+
+- an issue closes only when evidence exists in the repository, checks, or linked delivery artifacts
+- if something remains open, it is written back as new work instead of buried in a closing comment
+- closed issues should not retain `state:*` labels
+
 ## Labels
 
 ### Type
@@ -80,7 +108,15 @@
 - `--sync-issue-labels` is an explicit repair mode and should only be used when intentionally resetting issue labels to the seeded baseline
 - `--delete-default-labels` and `--protect-main` are explicit operations and do not trigger a full backlog reseed on their own
 
-## Known external blocker
+## Human and subagent contract
 
-- Branch protection for `main` on a private repository requires a GitHub plan that supports protected branches on private repos
-- If the current plan does not support that capability, the bootstrap script fails closed with a clear error instead of silently skipping protection
+- humans decide roadmap, approvals, and irreversible product direction
+- subagents work from explicit issues with bounded scope
+- no subagent should execute outside the issue it was given
+- every incomplete result returns to GitHub with status and evidence
+
+## Branch protection status
+
+- `main` is protected with required pull requests, CODEOWNERS review, conversation resolution, and required checks
+- The temporary private-repo blocker was resolved by making the repository public on `2026-04-22`
+- The bootstrap script still fails closed if protection cannot be applied in a future environment

--- a/docs/brand/brand-guide-v0.md
+++ b/docs/brand/brand-guide-v0.md
@@ -1,0 +1,77 @@
+# Brand Guide v0
+
+## Brand identity
+
+- Editorial name: `Agents Company by Escalona Labs`
+- Product short name: `Agents Company`
+- Brand parent: `Escalona Labs`
+
+## Brand promise
+
+Agents Company should feel precise, editorial, and calm under pressure. The brand is not playful swarm theater; it is disciplined coordination made visible.
+
+## Visual foundation
+
+### Core symbol
+
+Use the hexagon plus connected-node symbol as the primary mark.
+
+Meaning:
+
+- the hexagon signals structure and engineered containment
+- the node graph signals coordination, visibility, and connected execution
+
+### Wordmark
+
+- `Agents Company` carries the strongest visual weight
+- `by Escalona Labs` stays lighter and clearly secondary
+- keep the pair together in formal product surfaces until asset variants are finalized
+
+## Core palette
+
+- `brand.navy = #17355f`
+- `brand.sky = #71c9ff`
+- `brand.blue = #356fa8`
+- `brand.ice = #eef6fb`
+
+## Color usage
+
+- use `brand.navy` for primary text, product chrome, and structural UI surfaces
+- use `brand.sky` for active states, highlights, network motifs, and key accents
+- use `brand.blue` as a supporting tone for secondary emphasis
+- use `brand.ice` for calm light backgrounds, panels, and spacious layouts
+
+## Tone of voice
+
+- direct, composed, and technical
+- evidence-led rather than hype-led
+- confident without sounding theatrical
+- specific about control, safety, and determinism
+
+## Logo rules
+
+- do not rotate, stretch, or recolor the symbol outside the approved palette
+- do not separate the internal node graph from the hexagon in primary product contexts
+- keep generous whitespace around the symbol-wordmark lockup
+- prefer light backgrounds until inverse variants are formally approved
+
+## Product surface rules
+
+- default to navy-led interfaces with sky accents instead of generic purple or neon agent styling
+- diagrams and UI should imply orchestration, evidence, and flow rather than anthropomorphic agents
+- brand elements must reinforce that this is a control system, not a chat toy
+
+## Asset backlog
+
+- SVG master logo
+- monochrome mark
+- app icon set
+- favicon
+- social preview image
+- release artwork
+
+## Brand guardrails
+
+- do not reference legacy product names in any visible product surface
+- do not mix Escalona Labs branding with third-party product marks in a way that implies endorsement
+- keep public-license messaging aligned with the repository license posture

--- a/docs/brand/technical-naming-system.md
+++ b/docs/brand/technical-naming-system.md
@@ -1,0 +1,66 @@
+# Technical Naming System
+
+## Naming principles
+
+- one canonical name per technical surface
+- editorial branding and technical identifiers are related but not interchangeable
+- no visible legacy product identifiers remain in the new system
+
+## Canonical map
+
+| Surface | Canonical name |
+| --- | --- |
+| Editorial product name | `Agents Company by Escalona Labs` |
+| Product short name | `Agents Company` |
+| Technical short name | `agents-company` |
+| Repository slug | `agents-company-escalona-labs` |
+| GitHub owner | `escalonalabs` |
+| npm scope | `@escalonalabs/*` |
+| Primary Go module root | `github.com/escalonalabs/agents-company-escalona-labs/server` |
+| Public CLI | `agents-company` |
+| Desktop app id | `labs.escalona.agentscompany.desktop` |
+| Deep link scheme | `agents-company://` |
+| Environment prefix | `AGENTS_COMPANY_` |
+| Storage key prefix | `agents_company_` |
+| Local state directory | `~/.agents-company` |
+| Local workspace root | `~/agents_company_workspaces` |
+| Release channel prefix | `agents-company-` |
+
+## Package naming rules
+
+- published or internal packages use `@escalonalabs/<package-name>`
+- package names stay descriptive by bounded context, for example:
+  - `@escalonalabs/domain`
+  - `@escalonalabs/kernel`
+  - `@escalonalabs/github`
+  - `@escalonalabs/ui`
+
+## Go naming rules
+
+- the first Go module lives under `server/`
+- subpackages should follow context-driven names such as `internal/kernel`, `internal/githubsync`, and `internal/orchestration`
+- no legacy brand identifiers may appear in module paths, package names, or generated import paths
+
+## App and integration naming rules
+
+- UI apps should use descriptive folder names such as `control-web`
+- server processes should use role-based names such as `control-plane` and `github-app`
+- integrations should describe their responsibility, not their transport alone
+
+## Persistence naming rules
+
+- environment variables use uppercase `AGENTS_COMPANY_*`
+- database schemas, tables, queues, and buckets should prefer `agents_company_*`
+- no user-facing storage key should expose legacy names
+
+## Release and distribution rules
+
+- release names and artifacts start with `agents-company-`
+- repository docs should call the product `Agents Company by Escalona Labs` on first mention and `Agents Company` thereafter
+- executable surfaces should prefer the shorter technical identifier when brevity matters
+
+## Reserved words
+
+- `Escalona Labs` is reserved for company attribution and formal brand contexts
+- `Agents Company` is reserved for product-facing references
+- `agents-company` is reserved for technical identifiers, paths, and executable surfaces

--- a/docs/foundation/monorepo-topology.md
+++ b/docs/foundation/monorepo-topology.md
@@ -1,0 +1,151 @@
+# Monorepo Topology And Bounded Contexts
+
+## Goal
+
+Define package and application seams once, early, so the platform can grow without repeatedly renaming the same boundary or mixing runtime concerns with UI and integration code.
+
+## Top-level layout
+
+```text
+apps/
+  control-web/
+  docs-site/                  # later
+packages/
+  domain/
+  kernel/
+  orchestration/
+  execution/
+  memory/
+  github/
+  sdk/
+  ui/
+server/
+  control-plane/
+  github-app/
+docs/
+  adr/
+  foundation/
+  roadmap/
+  brand/
+  backlog/
+  operations/
+```
+
+## Bounded contexts
+
+### Domain
+
+Owns canonical types and invariants for company, objective, work item, run, approval, artifact, and policy references.
+
+Rules:
+
+- no GitHub client logic
+- no UI concerns
+- no transport-specific behavior
+- shared by kernel, server, and SDK surfaces
+
+### Kernel
+
+Owns state machine, event model, ledger semantics, replay, idempotency, and projections from runtime truth.
+
+Rules:
+
+- deterministic logic only
+- no direct browser or shell execution
+- no GitHub write side-effects inside reducers
+
+### Orchestration
+
+Owns objective compilation, planning, scheduling, leases, retries, concurrency caps, and escalation triggers.
+
+Rules:
+
+- consumes domain and kernel contracts
+- cannot bypass approvals or execution packet freezing
+
+### Execution
+
+Owns tool contracts, executor boundaries, artifact capture, task-result validation, and capability policy enforcement.
+
+Rules:
+
+- effects are explicit and auditable
+- invalid outputs stop continuity
+- transport adapters stay outside kernel logic
+
+### Memory
+
+Owns memory strata, retrieval policy, provenance graph, retention logic, and evaluation harnesses.
+
+Rules:
+
+- memory informs planning and review but does not silently rewrite runtime truth
+
+### GitHub
+
+Owns projections into issues, comments, checks, milestones, reconciliation, and drift detection.
+
+Rules:
+
+- GitHub mirrors progress for humans
+- GitHub does not become the transaction ledger
+
+### SDK
+
+Owns stable external contracts for clients, internal tooling, and future automation integrations.
+
+Rules:
+
+- wraps public types and transport-safe payloads
+- does not expose unstable internal reducers directly
+
+### UI
+
+Owns operator-facing components, design system primitives, and views over control-plane data.
+
+Rules:
+
+- UI reads projected state and control APIs
+- UI does not invent execution semantics
+
+## Application boundaries
+
+### `apps/control-web`
+
+Primary operator UI for timelines, approvals, drift, and company onboarding.
+
+### `server/control-plane`
+
+Backend API for timelines, event streams, approvals, control endpoints, and operator actions.
+
+### `server/github-app`
+
+Dedicated surface for GitHub webhooks, outbound sync, reconciliation, and audit events.
+
+## Ownership model
+
+- `packages/domain` and `packages/kernel` are architectural core and require the highest review bar
+- `packages/orchestration`, `packages/execution`, `packages/memory`, and `packages/github` are policy-heavy domains with explicit contract tests
+- `apps/control-web` and `packages/ui` can evolve faster as long as they do not redefine kernel semantics
+- `server/control-plane` composes services; it should not absorb domain logic that belongs in packages
+
+## Clean-room advantages
+
+- concepts inspired by external systems can be re-authored without importing their code shape
+- contracts stay native to Escalona Labs naming and semantics
+- each context can be implemented incrementally with contract tests instead of giant rewrites
+
+## Boundary rules that must hold
+
+- reducers never call tools
+- GitHub sync never mutates ledger truth directly
+- execution adapters never define business workflow state
+- UI does not couple itself to raw ledger internals
+- naming lives in one canonical map and is reused everywhere else
+
+## Sequencing
+
+1. Define domain and kernel contracts
+2. Add GitHub projection and orchestration contracts
+3. Implement execution and memory boundaries
+4. Build server and UI around those stable seams

--- a/docs/foundation/product-charter.md
+++ b/docs/foundation/product-charter.md
@@ -1,0 +1,134 @@
+# Product Charter
+
+## Product identity
+
+- Editorial name: `Agents Company by Escalona Labs`
+- Product short name: `Agents Company`
+- Technical short name: `agents-company`
+
+## Mission
+
+Build a deterministic company-of-agents platform that lets humans plan, supervise, and audit complex agent work through GitHub without turning chat transcripts into the system of record.
+
+## Problem statement
+
+Current agent teams fail in predictable ways:
+
+- coordination drifts into repetitive conversational loops
+- execution state gets mixed with human discussion
+- continuity depends on fragile transcripts instead of durable artifacts
+- humans cannot easily tell what is blocked, safe, or actually complete
+
+Agents Company exists to separate progress from chatter, execution from narration, and deterministic runtime truth from human collaboration surfaces.
+
+## Product thesis
+
+The platform wins when it combines two layers cleanly:
+
+1. An internal deterministic kernel that owns execution state, replay, approvals, leases, and fail-closed transitions.
+2. A GitHub-first operating model that projects work into issues, pull requests, comments, checks, and milestones for human coordination.
+
+GitHub is the human progress layer. It is not the runtime ledger.
+
+## Primary users
+
+### Founder-operator
+
+Needs one place to see what agents are doing, what is blocked, what needs approval, and what shipped.
+
+### Platform builder
+
+Needs strong contracts, replayability, and clean seams to evolve the kernel without rewriting the product surface.
+
+### Human reviewer
+
+Needs evidence, not long chat transcripts, in order to review output and approve or reject work safely.
+
+### Specialized subagent
+
+Needs bounded tasks, stable context, and unambiguous ownership instead of open-ended conversational orchestration.
+
+## MVP scope
+
+### In scope
+
+- deterministic kernel contracts for objectives, work items, runs, approvals, artifacts, and replay
+- GitHub-first backlog, milestone, issue, and PR operating model
+- company orchestration semantics with explicit leases, retries, and approval boundaries
+- execution packet and task-result contracts that fail closed
+- memory and provenance design strong enough for evaluation and later implementation
+- control-plane foundations for operator timeline, drift awareness, and first-company bootstrap
+
+### Out of scope for MVP
+
+- marketplace dynamics, autonomous budgeting, or internal token economies
+- general-purpose open-ended social chat between agents
+- last-write-wins collaboration over exclusive artifacts
+- full enterprise packaging, billing, or multi-tenant SaaS polish
+- broad third-party ecosystem expansion before kernel and GitHub projection are stable
+
+## Non-goals
+
+- replicate the old platform behavior under a new name
+- maximize the raw number of active agents at the expense of clarity
+- hide uncertainty behind optimistic automation
+- make GitHub the runtime source of truth
+
+## Product principles
+
+- Determinism before convenience
+- Evidence before continuity
+- GitHub-first for humans, internal ledger for runtime truth
+- Fail closed instead of guessing
+- One bounded owner for each meaningful slice of work
+- Naming and brand consistency from day one
+- Clean-room implementation only
+
+## Success criteria for M0 to M2
+
+- a new contributor can understand the backlog and operating model from the repo alone
+- core architectural terms have one shared meaning
+- foundation decisions do not need to be renamed or re-argued in M1 and M2
+- GitHub and kernel responsibilities stay clearly separated
+
+## Glossary
+
+### Company
+
+A configured operating unit composed of humans, agents, policies, and delivery surfaces.
+
+### Objective
+
+A high-level business or delivery outcome compiled into executable work.
+
+### Work item
+
+A bounded unit of planned work with one owner, explicit validation intent, and stable lifecycle.
+
+### Run
+
+One concrete execution attempt for a work item under a frozen packet and deterministic rules.
+
+### Execution packet
+
+An immutable input envelope that freezes context, permissions, tools, and expected result shape for a run.
+
+### Approval
+
+A human or policy-gated decision required before a work item may continue across a control boundary.
+
+### Artifact
+
+Any durable output produced or consumed by the system, including code, logs, attachments, docs, and evaluation evidence.
+
+### Projection
+
+A human-facing representation of internal runtime state in GitHub or other operator surfaces.
+
+### Drift
+
+A detectable mismatch between the internal ledger and an external projection such as GitHub.
+
+### Replay
+
+Deterministic reconstruction of prior runtime behavior from ledgered events and frozen inputs.

--- a/docs/operations/clean-room-policy.md
+++ b/docs/operations/clean-room-policy.md
@@ -1,0 +1,60 @@
+# Clean-Room Policy And Provenance Checklist
+
+## Purpose
+
+This repository is built under a strict clean-room rule. External products, codebases, prompts, repos, and papers may inform requirements or constraints, but implementation in this repository must be authored here from scratch.
+
+## Allowed inputs
+
+- high-level product requirements
+- public documentation, specs, and standards
+- architectural lessons learned from prior systems
+- problem statements, failure patterns, and user pain points
+- original design documents, ADRs, benchmarks, and test cases written for this repository
+
+## Forbidden inputs
+
+- copying source code, tests, prompts, assets, or templates from third-party or legacy products
+- porting code through translation, paraphrase, or superficial renaming
+- recreating proprietary UX text or implementation structure line by line
+- using external repos as a hidden starter kit while claiming the result is original
+
+## Working rule
+
+Inspiration may shape what we build. It must not determine the literal code, file structure, or product wording we paste into this repository.
+
+## Required provenance posture
+
+When a change is proposed, the author should be able to answer:
+
+- what requirement or problem this change solves
+- what original document, issue, or ADR inside this repository justified it
+- what external ideas informed the design at a conceptual level
+- why the final implementation is original to this repository
+
+## Contributor checklist
+
+Before opening or merging a change, confirm:
+
+- the work traces back to a GitHub issue, ADR, or repository-owned plan
+- no external code or protected assets were copied into the branch
+- names, comments, and docs were written freshly for Escalona Labs
+- any outside inspiration is described as influence, not imported implementation
+- any generated artifacts were reviewed for accidental carryover of third-party identifiers
+
+## Review checklist
+
+Reviewers should challenge:
+
+- suspiciously familiar file structure or wording
+- copied tests, comments, or naming from external systems
+- assets or prompts with unclear origin
+- changes that cannot explain their repository-local source of truth
+
+## Escalation rule
+
+If provenance is unclear, the change stops. The default action is to rewrite or remove the questionable material rather than argue it through.
+
+## Relationship to licensing
+
+The repository license governs how others may use this repository. The clean-room policy governs how this repository itself is authored.

--- a/docs/operations/licensing-and-commercial-use.md
+++ b/docs/operations/licensing-and-commercial-use.md
@@ -1,0 +1,28 @@
+# Licensing And Commercial Use
+
+## License posture
+
+This repository is public but not open source.
+
+The source is available under the `Escalona Labs Public Source License 1.0`, which allows
+inspection, evaluation, research, and other non-commercial uses while prohibiting commercial
+use without prior written permission from Escalona Labs.
+
+## Working rules
+
+- Treat all repository contents as source-available proprietary material
+- Do not promise commercial rights in issues, pull requests, or docs
+- Do not remove or weaken copyright, trademark, or license notices
+- Keep Escalona Labs branding separate from third-party marks and assets
+
+## Commercial path
+
+- Any commercial use requires a separate written agreement from Escalona Labs
+- The public repository must not imply that commercial use is pre-approved
+- If future packaging or distribution surfaces are added, they must carry the same license posture
+
+## Repository requirements
+
+- `LICENSE` is the controlling document for repository use
+- `README.md` must clearly state that the repository is public source-available code, not open source
+- Package metadata should point to the repository license file instead of claiming an OSI license

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "agents-company",
   "version": "0.0.0",
   "private": true,
+  "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "engines": {
@@ -12,4 +13,3 @@
     "check:repo": "python3 .github/scripts/repo_guardrails.py"
   }
 }
-


### PR DESCRIPTION
## Summary
- make the repository public and add a source-available commercial-use restriction
- document product charter, monorepo topology, brand guide, technical naming, and clean-room policy
- strengthen the GitHub operating model and close the initial M0 foundation issues

## Issues
- closes #1
- closes #2
- closes #3
- closes #4
- closes #5
- closes #6
- closes #7

## Validation
- python3 .github/scripts/repo_guardrails.py
- branch protection verified on `main`
- GitHub issue states synchronized with repository artifacts