### PR TITLE
docs: define github backbone contracts

### DIFF
--- a/docs/github-backbone/README.md
+++ b/docs/github-backbone/README.md
@@ -1,0 +1,19 @@
+# GitHub Backbone Docs
+
+This directory defines the GitHub projection and reconciliation contracts for `M2 GitHub Backbone`.
+
+## Documents
+
+- `kernel-to-github-mapping.md` maps to `AC-201`
+- `github-app-auth-and-permissions.md` maps to `AC-202`
+- `outbound-github-synchronization.md` maps to `AC-203`
+- `inbound-reconciliation-and-conflict-handling.md` maps to `AC-204`
+- `drift-detection-and-audit-rules.md` maps to `AC-205`
+
+## Reading order
+
+1. kernel-to-GitHub mapping
+2. GitHub App authentication and permissions
+3. outbound synchronization
+4. inbound reconciliation and conflict handling
+5. drift detection and audit rules

--- a/docs/github-backbone/drift-detection-and-audit-rules.md
+++ b/docs/github-backbone/drift-detection-and-audit-rules.md
@@ -1,0 +1,88 @@
+# Drift Detection And Audit Rules
+
+## Purpose
+
+Define how the platform detects, classifies, stores, and explains divergence between kernel truth and GitHub projections.
+
+## Drift definition
+
+Drift exists when a GitHub projection no longer matches the latest canonical intent or observable state recorded in the kernel.
+
+## Drift classes
+
+### Projection lag
+
+The kernel is ahead, but GitHub has not been updated yet.
+
+### Delivery failure
+
+The projection worker attempted delivery and failed.
+
+### Unauthorized mutation
+
+A protected GitHub field was changed outside the allowed command paths.
+
+### Missing object
+
+Expected issue, comment, or check is missing in GitHub.
+
+### Metadata mismatch
+
+Hidden metadata or linkage identifiers no longer match the target aggregate.
+
+### Policy mismatch
+
+GitHub appears to show a state that the kernel would never authorize, such as a completed item after approval denial.
+
+## Drift record
+
+Every detected drift should store:
+
+- `drift_id`
+- `company_id`
+- `aggregate_type`
+- `aggregate_id`
+- `github_object_ref`
+- `drift_class`
+- `severity`
+- `source_event_id`
+- `observed_at`
+- `repair_status`
+- `notes`
+
+## Severity guidance
+
+- `info`: lag or harmless formatting divergence
+- `warn`: recoverable sync mismatch
+- `high`: protected field mismatch or missing object blocking operators
+- `critical`: divergence that could mislead approvals or delivery decisions
+
+## Audit rules
+
+- all projection writes must be traceable to source event ids
+- all inbound reconcile decisions must reference the triggering GitHub event id
+- all repairs must leave an audit trail even if the user-facing issue body is overwritten
+
+## Repair policy
+
+- benign drift may be repaired silently on next projection cycle
+- high or critical drift should leave a visible note for operators
+- repeated drift on the same object should escalate to a human review queue
+
+## Operator view
+
+The control plane should eventually expose:
+
+- current drift count by severity
+- oldest unrepaired drift
+- affected objectives and work items
+- last successful projection time
+
+## Success condition
+
+An operator should always be able to answer:
+
+- what diverged
+- when it diverged
+- what the kernel thinks is true
+- whether the system repaired it or needs human action

--- a/docs/github-backbone/github-app-auth-and-permissions.md
+++ b/docs/github-backbone/github-app-auth-and-permissions.md
@@ -1,0 +1,76 @@
+# GitHub App Authentication And Permissions
+
+## Purpose
+
+Define the installation model, token flow, and least-privilege permissions for the GitHub App that projects kernel truth into GitHub and accepts safe inbound operator intent.
+
+## Installation model
+
+- one GitHub App owned by Escalona Labs
+- installation occurs at organization or user-account scope
+- each company stores the GitHub installation reference, not a personal access token
+
+## Authentication flow
+
+1. control plane redirects operator to install the GitHub App
+2. installation identifier is stored against the company
+3. the backend signs a short-lived JWT with the app private key
+4. the backend exchanges the JWT for an installation access token
+5. the installation token is used for GitHub API calls until expiry
+
+## Secret handling
+
+- private key stored only in server-side secret storage
+- installation tokens are short-lived and never stored in plaintext long-term
+- no user PAT should be required for runtime projection
+
+## Minimum repository permissions
+
+### Required
+
+- `metadata: read`
+- `issues: read/write`
+- `pull_requests: read/write`
+- `checks: read/write`
+- `contents: read`
+
+### Optional later
+
+- `actions: read`
+- `members: read`
+
+### Not required for MVP
+
+- code scanning write
+- secrets write
+- administration write
+
+## Webhook subscriptions
+
+- `issues`
+- `issue_comment`
+- `pull_request`
+- `pull_request_review`
+- `check_run`
+- `check_suite`
+- `installation`
+- `installation_repositories`
+- `repository`
+
+## Permission posture
+
+- write only where human-facing projection requires it
+- read inbound events broadly enough to detect drift and human intent
+- avoid administration scope unless a later milestone truly needs branch or repository mutation
+
+## Token rules
+
+- installation token scoped to the installed repositories only
+- token refresh handled by backend on demand
+- token expiry and failure become integration events, not hidden runtime exceptions
+
+## Failure boundaries
+
+- missing installation blocks projection for that company, not the whole platform
+- missing write permission triggers drift or projection failure events
+- the app must never fall back to a broader credential silently

--- a/docs/github-backbone/inbound-reconciliation-and-conflict-handling.md
+++ b/docs/github-backbone/inbound-reconciliation-and-conflict-handling.md
@@ -1,0 +1,101 @@
+# Inbound Reconciliation And Conflict Handling
+
+## Purpose
+
+Define how human GitHub edits and external GitHub changes are interpreted, validated, and reconciled against the internal ledger without silent state corruption.
+
+## Inbound principle
+
+Inbound GitHub activity is not truth by default. It is either:
+
+- accepted as an explicit human intent signal, or
+- recorded as external drift requiring reconciliation
+
+## Safe inbound actions
+
+These may be mapped into kernel commands when policy allows:
+
+- explicit approval comment or review from an authorized actor
+- explicit cancellation request
+- explicit unblock or reprioritization command
+- explicit label changes on a small allowlist
+
+## Non-authoritative actions
+
+These do not directly mutate kernel truth:
+
+- free-form issue title edits
+- arbitrary body edits
+- manual issue close without an allowed command path
+- comment narration with no recognized command
+
+These become reconciliation candidates or drift events.
+
+## Reconciliation stages
+
+1. receive webhook event
+2. resolve target aggregate through metadata block
+3. classify the action as allowed intent, benign divergence, or conflict
+4. emit reconciliation or drift event
+5. either apply a kernel command or re-project canonical truth back to GitHub
+
+## Conflict classes
+
+### Benign divergence
+
+Pure formatting drift or non-authoritative prose changes.
+
+Response:
+
+- retain for audit
+- optionally overwrite on next canonical projection
+
+### Intent mismatch
+
+Human attempted to express a valid intent through the wrong GitHub surface.
+
+Response:
+
+- record reconciliation note
+- do not mutate kernel truth automatically
+
+### Authoritative conflict
+
+Human edit directly contradicts kernel truth on a protected field.
+
+Response:
+
+- emit drift
+- re-project canonical state
+- notify operators if repeated
+
+### Missing linkage
+
+GitHub object lacks metadata or references an unknown aggregate.
+
+Response:
+
+- quarantine as unlinked activity
+- require manual reconcile
+
+## Protected fields
+
+Protected fields must not be directly trusted inbound:
+
+- aggregate status
+- approval outcome
+- retry count
+- run terminal state
+- claim ownership
+
+## Allowed command channels
+
+For MVP, prefer explicit structured channels:
+
+- slash-style issue comments
+- GitHub review approval on linked PRs
+- limited allowlist labels
+
+## Conflict resolution rule
+
+When GitHub and kernel disagree on protected state, the kernel wins and GitHub is repaired or annotated.

--- a/docs/github-backbone/kernel-to-github-mapping.md
+++ b/docs/github-backbone/kernel-to-github-mapping.md
@@ -1,0 +1,153 @@
+# Kernel-To-GitHub Mapping
+
+## Purpose
+
+Define how deterministic kernel truth projects into GitHub issues, milestones, comments, checks, and metadata without turning GitHub into the write authority.
+
+## Mapping principles
+
+- the kernel owns truth; GitHub owns human readability
+- every GitHub artifact must map back to a stable kernel identifier
+- GitHub state may suggest intent, but it does not silently mutate runtime truth
+- projections must be idempotent and rebuildable
+
+## Canonical object mapping
+
+### Objective
+
+Projected as:
+
+- one GitHub issue labeled `type:epic`
+- milestone association when needed for release planning
+
+GitHub fields:
+
+- issue title mirrors objective title
+- issue body contains objective summary and machine-readable metadata block
+- labels carry planning signals such as priority, area, and track
+
+### Work item
+
+Projected as:
+
+- one GitHub issue
+
+GitHub fields:
+
+- issue title mirrors work item title
+- issue body includes bounded description, validation target, and metadata block
+- labels mirror work-item classification and operator-visible state
+
+### Approval
+
+Projected as:
+
+- issue comment thread on the work item
+- optional check run summary on the related PR or issue-linked commit
+
+Rule:
+
+- approval status may be visible in GitHub, but the canonical approval aggregate remains in the kernel
+
+### Run
+
+Projected as:
+
+- issue comments for narrative checkpoints
+- check runs for machine-verifiable execution status
+
+Rule:
+
+- GitHub never stores run truth as the only source of status
+
+### Artifact
+
+Projected as:
+
+- issue comment attachments, links, or check-run summaries
+
+Rule:
+
+- GitHub stores references to artifact locations, not the only copy of the artifact when durability matters
+
+## GitHub surfaces by responsibility
+
+### Issues
+
+Used for:
+
+- objective and work-item identity
+- human-readable status
+- validation intent
+- blockers and decisions
+
+### Milestones
+
+Used for:
+
+- roadmap grouping
+- high-level planning cadence
+
+### Labels
+
+Used for:
+
+- type
+- area
+- priority
+- readiness or blocked state
+- track membership
+
+### Comments
+
+Used for:
+
+- run narration
+- approval requests
+- reconciliation notes
+- drift evidence
+
+### Check runs
+
+Used for:
+
+- execution progress summaries
+- validation pass/fail surfaces
+- machine-oriented status tied to commits or PRs
+
+## Required metadata block
+
+Each projected issue should contain a hidden metadata block with:
+
+- `projection_version`
+- `company_id`
+- `aggregate_type`
+- `aggregate_id`
+- `source_event_id`
+- `projection_delivery_id`
+
+Purpose:
+
+- allow deterministic reconciliation without parsing free-form prose
+
+## Example mapping summary
+
+- `objective` -> epic issue
+- `work_item` -> issue
+- `run` -> comment thread plus check run
+- `approval` -> comment plus status summary
+- `artifact` -> linked evidence
+
+## What GitHub must never own
+
+- aggregate sequence numbers
+- replay truth
+- retry authority
+- approval authority after the kernel has recorded a denial or expiry
+- exclusive claim resolution
+
+## Operator clarity rules
+
+- titles and labels should stay human-readable
+- machine metadata should be hidden or clearly separated from prose
+- one work item should not project into multiple live issues unless explicitly split by the kernel

--- a/docs/github-backbone/outbound-github-synchronization.md
+++ b/docs/github-backbone/outbound-github-synchronization.md
@@ -1,0 +1,89 @@
+# Outbound GitHub Synchronization
+
+## Purpose
+
+Define how kernel events are projected into GitHub in a deterministic, observable, and idempotent way.
+
+## Sync model
+
+Outbound sync is driven from the kernel projection outbox, not from ad hoc direct API calls buried inside reducers.
+
+## Delivery pipeline
+
+1. canonical event enters the ledger
+2. projection rule determines whether GitHub should be updated
+3. one outbox delivery is enqueued with delivery key and source event reference
+4. GitHub worker performs the API call
+5. result is recorded as `projection.applied` or `projection.failed`
+
+## Delivery key
+
+Each outbound delivery must include an idempotency-friendly key built from:
+
+- `projection_name`
+- `aggregate_id`
+- `source_event_id`
+- `target_github_object`
+- `action_type`
+
+## Outbound action types
+
+- create issue
+- update issue body
+- sync labels
+- add comment
+- create or update check run
+- close issue
+- reopen issue
+- add milestone link
+- post drift note
+
+## Deterministic sync rules
+
+- one source event may emit many projection deliveries, but each delivery key is unique
+- repeated processing of the same source event must not create duplicate comments or duplicate issues
+- comment templates and metadata blocks must be versioned
+
+## Comment policy
+
+Use comments for:
+
+- run started
+- run blocked
+- approval requested
+- validation failed
+- drift detected
+
+Do not use comments as the only machine-readable state representation.
+
+## Check-run policy
+
+Use checks for:
+
+- machine-verifiable execution status
+- validation status
+- artifact links
+
+Checks should summarize the run and link back to the work-item issue.
+
+## Retry policy
+
+- transient GitHub API failures retry through the outbox with bounded backoff
+- permanent mapping or permission failures do not spin forever; they surface as drift or operator action items
+
+## Observability
+
+Every delivery should record:
+
+- source event id
+- GitHub object id
+- delivery key
+- attempt count
+- last error if failed
+- applied timestamp
+
+## Forbidden patterns
+
+- reducers calling GitHub APIs directly
+- using GitHub response data as the new source of runtime truth
+- posting duplicate comments for the same source event


### PR DESCRIPTION
## Summary
- define the kernel-to-GitHub mapping for objectives, work items, runs, approvals, and artifacts
- specify GitHub App auth, outbound sync, inbound reconciliation, and drift/audit rules
- establish the first implementation-grade contract package for M2 GitHub Backbone

## Issues
- closes #13
- closes #14
- closes #15
- closes #16
- closes #17

## Validation
- python3 .github/scripts/repo_guardrails.py