### PR TITLE
feat: define alpha readiness and replay gate

### DIFF
--- a/.github/scripts/bootstrap_github.py
+++ b/.github/scripts/bootstrap_github.py
@@ -27,6 +27,7 @@ REQUIRED_STATUS_CHECKS = [
     "repo-guardrails",
     "dependency-review",
     "secret-scan",
+    "replay-regression",
 ]
 
 

--- a/.github/scripts/check_replay_regression.py
+++ b/.github/scripts/check_replay_regression.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_DIR = REPO_ROOT / "tests" / "golden" / "kernel"
+REQUIRED_FIXTURES = {
+    "happy-path.json": "happy_path",
+    "approval-gate.json": "approval_gate",
+    "approval-denied.json": "approval_denied",
+    "duplicate-command.json": "duplicate_command",
+    "transient-retry.json": "transient_retry",
+    "permanent-validation-failure.json": "permanent_validation_failure",
+    "claim-expiry.json": "claim_expiry",
+    "projection-drift.json": "projection_drift",
+    "known-loop-prevention.json": "known_loop_prevention",
+}
+REQUIRED_FIELDS = (
+    "trace_id",
+    "schema_version",
+    "scenario_name",
+    "seed_state",
+    "commands",
+    "expected_events",
+    "expected_terminal_aggregate_state",
+    "expected_projection_state",
+    "expected_invariants",
+)
+REQUIRED_INVARIANTS = {
+    "known-loop-prevention.json": {
+        "no_redispatch_without_new_causal_input",
+        "terminal_blocked_or_escalated",
+    },
+    "approval-denied.json": {
+        "no_execution_after_denial",
+    },
+    "claim-expiry.json": {
+        "expired_lease_cannot_continue",
+    },
+}
+
+
+def append(findings: list[str], message: str) -> None:
+    findings.append(message)
+
+
+def validate_command_entries(path: Path, commands: object, findings: list[str]) -> None:
+    if not isinstance(commands, list) or not commands:
+        append(findings, f"{path} must declare a non-empty commands array")
+        return
+    for index, item in enumerate(commands):
+        if not isinstance(item, dict):
+            append(findings, f"{path} command[{index}] must be an object")
+            continue
+        for key in ("command_id", "type", "issued_at"):
+            value = item.get(key)
+            if not isinstance(value, str) or not value.strip():
+                append(findings, f"{path} command[{index}] is missing string field {key}")
+
+
+def validate_event_entries(path: Path, events: object, findings: list[str]) -> None:
+    if not isinstance(events, list) or not events:
+        append(findings, f"{path} must declare a non-empty expected_events array")
+        return
+    for index, item in enumerate(events):
+        if not isinstance(item, dict):
+            append(findings, f"{path} expected_events[{index}] must be an object")
+            continue
+        for key in ("event_id", "type", "occurred_at"):
+            value = item.get(key)
+            if not isinstance(value, str) or not value.strip():
+                append(findings, f"{path} expected_events[{index}] is missing string field {key}")
+
+
+def validate_fixture(path: Path, data: object, seen_trace_ids: set[str], findings: list[str]) -> None:
+    if not isinstance(data, dict):
+        append(findings, f"{path} must contain a top-level object")
+        return
+
+    for field in REQUIRED_FIELDS:
+        if field not in data:
+            append(findings, f"{path} is missing required field {field}")
+
+    trace_id = data.get("trace_id")
+    if isinstance(trace_id, str) and trace_id.strip():
+        if trace_id in seen_trace_ids:
+            append(findings, f"{path} reuses duplicate trace_id {trace_id}")
+        seen_trace_ids.add(trace_id)
+    else:
+        append(findings, f"{path} must declare a non-empty trace_id")
+
+    schema_version = data.get("schema_version")
+    if schema_version != 1:
+        append(findings, f"{path} must use schema_version 1, found {schema_version!r}")
+
+    scenario_name = data.get("scenario_name")
+    if not isinstance(scenario_name, str) or not scenario_name.strip():
+        append(findings, f"{path} must declare a non-empty scenario_name")
+
+    for dict_field in ("seed_state", "expected_terminal_aggregate_state", "expected_projection_state"):
+        value = data.get(dict_field)
+        if not isinstance(value, dict):
+            append(findings, f"{path} field {dict_field} must be an object")
+
+    validate_command_entries(path, data.get("commands"), findings)
+    validate_event_entries(path, data.get("expected_events"), findings)
+
+    invariants = data.get("expected_invariants")
+    if not isinstance(invariants, list) or not invariants:
+        append(findings, f"{path} must declare a non-empty expected_invariants array")
+        invariant_set: set[str] = set()
+    else:
+        invariant_set = set()
+        for index, item in enumerate(invariants):
+            if not isinstance(item, str) or not item.strip():
+                append(findings, f"{path} expected_invariants[{index}] must be a non-empty string")
+                continue
+            invariant_set.add(item)
+
+    required_invariants = REQUIRED_INVARIANTS.get(path.name, set())
+    missing = sorted(required_invariants - invariant_set)
+    if missing:
+        append(findings, f"{path} is missing required invariants: {', '.join(missing)}")
+
+
+def main() -> int:
+    findings: list[str] = []
+    seen_trace_ids: set[str] = set()
+
+    if not FIXTURE_DIR.exists():
+        append(findings, f"Missing fixture directory: {FIXTURE_DIR.relative_to(REPO_ROOT)}")
+    else:
+        fixture_paths = sorted(FIXTURE_DIR.glob("*.json"))
+        fixture_names = {path.name for path in fixture_paths}
+
+        missing_fixtures = sorted(set(REQUIRED_FIXTURES) - fixture_names)
+        for name in missing_fixtures:
+            append(findings, f"Missing required replay fixture: tests/golden/kernel/{name}")
+
+        for path in fixture_paths:
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                append(findings, f"{path.relative_to(REPO_ROOT)} is not valid JSON: {exc}")
+                continue
+
+            validate_fixture(path.relative_to(REPO_ROOT), data, seen_trace_ids, findings)
+
+            expected_scenario = REQUIRED_FIXTURES.get(path.name)
+            scenario_name = data.get("scenario_name") if isinstance(data, dict) else None
+            if expected_scenario is not None and scenario_name != expected_scenario:
+                append(
+                    findings,
+                    f"{path.relative_to(REPO_ROOT)} must use scenario_name {expected_scenario}, found {scenario_name!r}",
+                )
+
+    if findings:
+        print("Replay regression check failed:")
+        for finding in findings:
+            print(f"- {finding}")
+        return 1
+
+    print("Replay regression fixtures passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/replay-regression.yml
+++ b/.github/workflows/replay-regression.yml
@@ -1,0 +1,20 @@
+name: replay-regression
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  replay-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate replay regression fixtures
+        run: python3 .github/scripts/check_replay_regression.py

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Agents Company is a clean-room rebuild for a GitHub-first company-of-agents plat
 
 - `docs/roadmap/` for delivery plans
 - `docs/adr/` for architectural decisions
+- `docs/alpha-readiness/` for launch gates, runbooks, and replay readiness
 - `docs/backlog/` for backlog mirrors and operating system notes
 - `docs/brand/` for naming and visual guidance
 - `docs/operations/` for contributor and delivery rules
@@ -31,6 +32,7 @@ Run the repository guardrails locally:
 
 ```bash
 pnpm check:repo
+pnpm check:replay
 ```
 
 ## Security

--- a/docs/alpha-readiness/README.md
+++ b/docs/alpha-readiness/README.md
@@ -1,0 +1,19 @@
+# Alpha Readiness Docs
+
+This directory defines the launch, validation, and operating contracts for `M7 Alpha Readiness`.
+
+## Documents
+
+- `service-levels-tracing-and-error-taxonomy.md` maps to `AC-701`
+- `replay-regression-in-ci.md` maps to `AC-702`
+- `security-review-permissions-secrets-and-auditability.md` maps to `AC-703`
+- `end-to-end-reference-workflows.md` maps to `AC-704`
+- `alpha-release-and-operational-runbook.md` maps to `AC-705`
+
+## Reading order
+
+1. service levels, tracing, and error taxonomy
+2. replay regression in CI
+3. security review for permissions, secrets, and auditability
+4. end-to-end reference workflows
+5. alpha release and operational runbook

--- a/docs/alpha-readiness/alpha-release-and-operational-runbook.md
+++ b/docs/alpha-readiness/alpha-release-and-operational-runbook.md
@@ -1,0 +1,66 @@
+# Alpha Release And Operational Runbook
+
+## Purpose
+
+Prepare the release checklist, rollback path, and day-one operating routine for alpha.
+
+## Preflight checklist
+
+- `repo-guardrails`, `dependency-review`, `secret-scan`, and `replay-regression` are green on `main`
+- required M7 documents are merged and linked from the release issue
+- GitHub App installation and webhook health are verified for the target company
+- operator dashboard shows healthy control-plane availability and projection freshness
+- open `sev0` and `sev1` items are zero
+
+## Release package
+
+The alpha handoff packet should include:
+
+- release scope summary
+- known limits and accepted residual risks
+- current SLOs and alert thresholds
+- linked reference workflows
+- rollback instructions
+- operator contact and escalation path
+
+## Launch sequence
+
+1. open the release issue and link the target commit or tag
+2. run the reference workflow checks in order
+3. verify GitHub projection freshness is within target
+4. verify no pending high-risk approvals are unresolved
+5. announce alpha open only after the above checks pass
+
+## Day-one operator routine
+
+- monitor availability, dispatch latency, and projection freshness
+- review pending approvals and drift alerts
+- review repeated invalid outputs or retry storms
+- document any manual override directly in GitHub and the operator timeline
+
+## Rollback triggers
+
+- repeated `sev1` projection integrity failures
+- control plane unavailable beyond the alpha SLO budget
+- invalid outputs bypassing downstream safety
+- missing or corrupt audit records for approvals or control actions
+
+## Rollback path
+
+1. freeze new objective intake
+2. cancel or pause unsafe work items through bounded control actions
+3. disable projection or executor paths causing unsafe churn
+4. restore the last known healthy release or feature flag posture
+5. write the incident and rollback evidence before reopening alpha
+
+## Post-incident rule
+
+No relaunch occurs from chat memory. Relaunch requires:
+
+- documented incident summary
+- explicit fix or mitigation
+- replay or workflow evidence showing the failure mode is contained
+
+## Exit condition
+
+Alpha operations are considered ready when launch, degraded operation, and rollback can all be executed from repository-owned artifacts without relying on tribal knowledge.

--- a/docs/alpha-readiness/end-to-end-reference-workflows.md
+++ b/docs/alpha-readiness/end-to-end-reference-workflows.md
@@ -1,0 +1,78 @@
+# End-To-End Reference Workflows
+
+## Purpose
+
+Define the small set of realistic workflows that will gate alpha readiness end to end.
+
+## Workflow 1: Modular feature delivery
+
+Scenario:
+
+- objective creates bounded backend, UI, and documentation work items
+- work items execute in parallel on non-overlapping scopes
+- GitHub issues, checks, and projection views stay aligned
+
+Must prove:
+
+- planner output is decomposable
+- scheduler enforces exclusive scope correctly
+- successful runs project cleanly into GitHub progress
+
+## Workflow 2: Approval-gated risky action
+
+Scenario:
+
+- a work item requires approval before an executor with elevated scope can run
+- operator grants or denies through the control plane
+
+Must prove:
+
+- execution pauses safely while approval is pending
+- denied approval prevents downstream continuity
+- approval history is visible in timeline and audit records
+
+## Workflow 3: Known loop suppression
+
+Scenario:
+
+- a historical `pending / verification pending / continue` pattern is replayed without new causal input
+
+Must prove:
+
+- scheduler suppresses no-op redispatch
+- system emits blocked, escalated, or review-needed state instead of churn
+- replay fixtures and operator timeline tell the same story
+
+## Workflow 4: Projection lag and drift recovery
+
+Scenario:
+
+- GitHub projection falls behind or diverges on a protected field
+
+Must prove:
+
+- drift alert points to the affected aggregate
+- runtime ledger remains authoritative
+- reconciliation can restore GitHub without corrupting runtime truth
+
+## Workflow 5: Alpha release drill
+
+Scenario:
+
+- preflight checks pass, release is opened, one degraded-path signal appears, and rollback is exercised
+
+Must prove:
+
+- launch checklist is executable
+- operators know which metrics and alerts decide go or no-go
+- rollback path is explicit and bounded
+
+## Acceptance rule
+
+Alpha is not gated by the number of workflows. It is gated by whether this set covers:
+
+- parallel work
+- approval safety
+- replay safety
+- GitHub projection integrity
+- operational launch discipline

--- a/docs/alpha-readiness/replay-regression-in-ci.md
+++ b/docs/alpha-readiness/replay-regression-in-ci.md
@@ -1,0 +1,61 @@
+# Replay Regression In CI
+
+## Purpose
+
+Define the merge gate that prevents replay and trace-contract regressions from landing unnoticed before the runtime is fully implemented.
+
+## Alpha gate design
+
+The initial replay gate is contract-first:
+
+- canonical fixtures live in `tests/golden/kernel/`
+- validation lives in `.github/scripts/check_replay_regression.py`
+- CI enforcement lives in `.github/workflows/replay-regression.yml`
+- branch protection requires the `replay-regression` check on `main`
+
+## What the gate validates today
+
+- every required golden-trace scenario exists
+- every trace fixture parses as valid JSON
+- required top-level fields exist and keep stable names
+- `trace_id` values stay unique
+- command and event entries remain machine-readable
+- known loop prevention retains hard invariants against no-op redispatch
+
+## Required alpha scenario baseline
+
+- happy path
+- approval gate
+- approval denial
+- duplicate command
+- transient retry
+- permanent validation failure
+- claim expiry
+- projection drift
+- known loop prevention
+
+## Fail-closed rule
+
+If a fixture becomes unreadable, drops a required scenario, or weakens a required invariant, the pull request must fail.
+
+## Why this is still useful before runtime implementation
+
+The platform already has contractual expectations for replay through:
+
+- golden trace harness design
+- scheduler safety rules
+- execution packet immutability
+- projection drift recovery
+
+This gate prevents those expectations from silently eroding while implementation catches up.
+
+## Upgrade path
+
+When the reducer and replay engine exist, the same workflow should add:
+
+- reducer execution against fixtures
+- exact event diffing
+- projection rebuild checks
+- invariant evaluation against materialized output
+
+The fixture format is intentionally strict enough to survive that upgrade without being replaced.

--- a/docs/alpha-readiness/security-review-permissions-secrets-and-auditability.md
+++ b/docs/alpha-readiness/security-review-permissions-secrets-and-auditability.md
@@ -1,0 +1,85 @@
+# Security Review For Permissions, Secrets, And Auditability
+
+## Purpose
+
+Close the alpha security review for the surfaces most likely to create irreversible damage: permissions, secrets, and auditability.
+
+## Review scope
+
+- GitHub App permissions and webhook handling
+- control-plane operator actions
+- executor capability and scope enforcement
+- secret storage and token handling
+- audit trail completeness for approvals, dispatch, and projection
+
+## Trust boundaries
+
+- operator browser to control plane
+- control plane to ledger and projections
+- control plane to GitHub App installation tokens
+- runtime to executor boundaries
+- executor to external tools
+
+## Permissions review
+
+### Accepted alpha posture
+
+- GitHub App holds only the minimum repository permissions already defined in the GitHub Backbone docs
+- operator actions enter the kernel as explicit commands
+- executor access is derived from capability, scope, and approval state, not prompt text
+- installation tokens are scoped to installed repositories only
+
+### Rejected alpha posture
+
+- no personal access token fallback
+- no executor-side self-escalation
+- no broad administration write on GitHub
+- no ambient shell or browser access outside the execution packet and policy snapshot
+
+## Secrets handling review
+
+- app private key stays in server-side secret storage only
+- installation tokens stay short-lived and are never persisted as durable plaintext state
+- executor secrets must be injected per run and referenced in audit metadata without writing secret material to logs or artifacts
+- secret rotation events must invalidate cached policy or connection state before the next dispatch
+
+## Auditability review
+
+Every alpha-critical decision must produce an auditable record for:
+
+- command acceptance
+- approval request and decision
+- lease acquisition and expiry
+- execution packet creation
+- task result validation
+- GitHub projection write or failure
+- drift detection and operator override
+
+## Required evidence fields
+
+- actor type
+- actor identifier
+- target aggregate
+- policy snapshot reference
+- before and after status summary
+- linked artifact or GitHub reference when applicable
+- timestamp and correlation identifiers
+
+## Residual risks accepted for alpha
+
+- replay gate is still contract-first rather than reducer-backed
+- GitHub remains a high-value external dependency for the human operating path
+- human review can still become a bottleneck even when the runtime behaves correctly
+
+## Alpha blockers
+
+Alpha is blocked if any of these remain true:
+
+- any runtime path still depends on a user PAT
+- any executor path can run outside explicit capability and scope policy
+- any approval or override action is not auditable
+- any projection failure can mutate runtime truth silently
+
+## Review conclusion
+
+Alpha may proceed only with fail-closed policy enforcement, server-side secret custody, and complete audit coverage for operator and runtime control actions.

--- a/docs/alpha-readiness/service-levels-tracing-and-error-taxonomy.md
+++ b/docs/alpha-readiness/service-levels-tracing-and-error-taxonomy.md
@@ -1,0 +1,143 @@
+# Service Levels, Tracing, And Error Taxonomy
+
+## Purpose
+
+Define the alpha operating language for health, latency, traceability, and failure handling so launches and incidents are evaluated against the same model.
+
+## Alpha service levels
+
+### Control plane availability
+
+- monthly availability target: `99.5%`
+- covers read APIs, operator timeline, pending approval views, and bounded control endpoints
+
+### Command acceptance latency
+
+- `p95 <= 5s` from authenticated operator request to accepted command id
+- excludes approval wait time and downstream executor runtime
+
+### Scheduler dispatch latency
+
+- `p95 <= 30s` from `work_item.ready` to active lease or explicit blocked state
+- `p99 <= 120s` during degraded mode
+
+### GitHub projection freshness
+
+- `p95 <= 60s` from committed ledger event to projected GitHub update
+- `p99 <= 300s` before a drift or lag alert must open
+
+### Approval visibility
+
+- `p95 <= 15s` from `approval.requested` to operator-visible pending approval
+
+## Tracing model
+
+Every operator-visible action must remain traceable across:
+
+- objective
+- work item
+- run
+- approval
+- execution packet
+- GitHub projection event
+
+## Required trace attributes
+
+- `company_id`
+- `objective_id`
+- `work_item_id`
+- `run_id`
+- `approval_id` when applicable
+- `execution_packet_id` when applicable
+- `github_installation_id` when applicable
+- `github_issue_number` when applicable
+- `policy_snapshot_ref`
+- `trace_outcome`
+
+## Required span families
+
+- planner compilation
+- scheduler lease acquisition
+- approval wait
+- executor dispatch
+- tool execution envelope validation
+- projection synchronization
+- drift detection
+- memory extraction
+
+## Error taxonomy
+
+### Validation errors
+
+- malformed commands
+- invalid execution packet
+- invalid task result
+- schema mismatches during replay or projection rebuild
+
+Retry rule:
+
+- no automatic retry until the upstream payload changes
+
+### Policy errors
+
+- missing capability
+- missing scope
+- missing approval
+- exceeded retry, budget, or concurrency cap
+
+Retry rule:
+
+- retry only after policy state changes
+
+### Execution errors
+
+- transient tool failure
+- executor timeout
+- unavailable dependency
+- cancelled run
+
+Retry rule:
+
+- bounded retry by policy and failure class
+
+### Projection errors
+
+- GitHub write rejected
+- GitHub object missing
+- protected-field drift
+- projection lag beyond freshness target
+
+Retry rule:
+
+- retry sync safely from ledger truth
+
+### Security errors
+
+- secret access denied
+- unsigned or untrusted callback
+- forbidden capability request
+- audit log write failure
+
+Retry rule:
+
+- fail closed and escalate
+
+## Severity model
+
+- `sev0`: data loss, integrity break, or unsafe execution continuity
+- `sev1`: alpha launch blocker or sustained SLO breach
+- `sev2`: degraded but bounded operation with manual workaround
+- `sev3`: local defect with no current user-facing breach
+
+## Alpha alerts
+
+- control plane availability burn alert
+- scheduler dispatch latency alert
+- projection freshness alert
+- repeated `invalid_output` alert
+- repeated drift alert on the same aggregate
+- audit write failure alert
+
+## Exit rule
+
+Alpha readiness requires dashboarding and alerts to use this taxonomy directly. No incident or health report should invent a parallel vocabulary.

--- a/docs/backlog/github-operating-system.md
+++ b/docs/backlog/github-operating-system.md
@@ -118,5 +118,6 @@
 ## Branch protection status
 
 - `main` is protected with required pull requests, CODEOWNERS review, conversation resolution, and required checks
+- required checks are `repo-guardrails`, `dependency-review`, `secret-scan`, and `replay-regression`
 - The temporary private-repo blocker was resolved by making the repository public on `2026-04-22`
 - The bootstrap script still fails closed if protection cannot be applied in a future environment

--- a/docs/roadmap/platform-rebuild.md
+++ b/docs/roadmap/platform-rebuild.md
@@ -74,6 +74,7 @@ Build a new company-of-agents platform under the Escalona Labs brand with a dete
 - Observability model defined
 - Replay regression enforced in CI
 - Security review closed
+- Reference workflows defined for launch gating
 - Release and rollback runbook ready
 
 ## Build order
@@ -84,4 +85,3 @@ Build a new company-of-agents platform under the Escalona Labs brand with a dete
 4. Orchestration and execution controls
 5. Memory and operator UX
 6. Alpha readiness and release discipline
-

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "pnpm": ">=10.0.0"
   },
   "scripts": {
-    "check:repo": "python3 .github/scripts/repo_guardrails.py"
+    "check:repo": "python3 .github/scripts/repo_guardrails.py",
+    "check:replay": "python3 .github/scripts/check_replay_regression.py"
   }
 }

--- a/tests/golden/kernel/approval-denied.json
+++ b/tests/golden/kernel/approval-denied.json
@@ -1,0 +1,52 @@
+{
+  "trace_id": "kernel/approval-denied/v1",
+  "schema_version": 1,
+  "scenario_name": "approval_denied",
+  "seed_state": {
+    "objective_id": "obj_approval_002",
+    "objective_status": "planned"
+  },
+  "commands": [
+    {
+      "command_id": "cmd_denied_001",
+      "type": "work_item.dispatch",
+      "issued_at": "2026-04-22T00:20:00Z"
+    },
+    {
+      "command_id": "cmd_denied_002",
+      "type": "approval.deny",
+      "issued_at": "2026-04-22T00:21:00Z"
+    }
+  ],
+  "expected_events": [
+    {
+      "event_id": "evt_denied_001",
+      "type": "approval.requested",
+      "occurred_at": "2026-04-22T00:20:02Z"
+    },
+    {
+      "event_id": "evt_denied_002",
+      "type": "approval.denied",
+      "occurred_at": "2026-04-22T00:21:00Z"
+    },
+    {
+      "event_id": "evt_denied_003",
+      "type": "work_item.blocked",
+      "occurred_at": "2026-04-22T00:21:01Z"
+    }
+  ],
+  "expected_terminal_aggregate_state": {
+    "approval_status": "denied",
+    "work_item_status": "blocked",
+    "run_status": "not_started"
+  },
+  "expected_projection_state": {
+    "pending_approvals": 0,
+    "github_issue_state": "open",
+    "block_reason": "approval_denied"
+  },
+  "expected_invariants": [
+    "no_execution_after_denial",
+    "explicit_human_override_required_to_resume"
+  ]
+}

--- a/tests/golden/kernel/approval-gate.json
+++ b/tests/golden/kernel/approval-gate.json
@@ -1,0 +1,52 @@
+{
+  "trace_id": "kernel/approval-gate/v1",
+  "schema_version": 1,
+  "scenario_name": "approval_gate",
+  "seed_state": {
+    "objective_id": "obj_approval_001",
+    "objective_status": "planned"
+  },
+  "commands": [
+    {
+      "command_id": "cmd_approval_001",
+      "type": "work_item.dispatch",
+      "issued_at": "2026-04-22T00:10:00Z"
+    },
+    {
+      "command_id": "cmd_approval_002",
+      "type": "approval.grant",
+      "issued_at": "2026-04-22T00:12:00Z"
+    }
+  ],
+  "expected_events": [
+    {
+      "event_id": "evt_approval_001",
+      "type": "approval.requested",
+      "occurred_at": "2026-04-22T00:10:05Z"
+    },
+    {
+      "event_id": "evt_approval_002",
+      "type": "approval.granted",
+      "occurred_at": "2026-04-22T00:12:00Z"
+    },
+    {
+      "event_id": "evt_approval_003",
+      "type": "run.completed.valid_success",
+      "occurred_at": "2026-04-22T00:13:15Z"
+    }
+  ],
+  "expected_terminal_aggregate_state": {
+    "approval_status": "granted",
+    "work_item_status": "completed",
+    "run_status": "valid_success"
+  },
+  "expected_projection_state": {
+    "pending_approvals": 0,
+    "latest_operator_action": "grant",
+    "active_runs": 0
+  },
+  "expected_invariants": [
+    "no_execution_before_approval",
+    "approval_history_is_auditable"
+  ]
+}

--- a/tests/golden/kernel/claim-expiry.json
+++ b/tests/golden/kernel/claim-expiry.json
@@ -1,0 +1,46 @@
+{
+  "trace_id": "kernel/claim-expiry/v1",
+  "schema_version": 1,
+  "scenario_name": "claim_expiry",
+  "seed_state": {
+    "objective_id": "obj_claim_001",
+    "objective_status": "ready"
+  },
+  "commands": [
+    {
+      "command_id": "cmd_claim_001",
+      "type": "work_item.dispatch",
+      "issued_at": "2026-04-22T01:00:00Z"
+    }
+  ],
+  "expected_events": [
+    {
+      "event_id": "evt_claim_001",
+      "type": "lease.acquired",
+      "occurred_at": "2026-04-22T01:00:01Z"
+    },
+    {
+      "event_id": "evt_claim_002",
+      "type": "lease.expired",
+      "occurred_at": "2026-04-22T01:05:01Z"
+    },
+    {
+      "event_id": "evt_claim_003",
+      "type": "work_item.requeued",
+      "occurred_at": "2026-04-22T01:05:02Z"
+    }
+  ],
+  "expected_terminal_aggregate_state": {
+    "lease_status": "expired",
+    "work_item_status": "ready",
+    "run_status": "cancelled"
+  },
+  "expected_projection_state": {
+    "active_runs": 0,
+    "queue_state": "requeued"
+  },
+  "expected_invariants": [
+    "expired_lease_cannot_continue",
+    "redispatch_requires_new_lease"
+  ]
+}

--- a/tests/golden/kernel/duplicate-command.json
+++ b/tests/golden/kernel/duplicate-command.json
@@ -1,0 +1,40 @@
+{
+  "trace_id": "kernel/duplicate-command/v1",
+  "schema_version": 1,
+  "scenario_name": "duplicate_command",
+  "seed_state": {
+    "objective_id": "obj_duplicate_001",
+    "objective_status": "planned"
+  },
+  "commands": [
+    {
+      "command_id": "cmd_duplicate_001",
+      "type": "objective.accepted",
+      "issued_at": "2026-04-22T00:30:00Z"
+    },
+    {
+      "command_id": "cmd_duplicate_001",
+      "type": "objective.accepted",
+      "issued_at": "2026-04-22T00:30:01Z"
+    }
+  ],
+  "expected_events": [
+    {
+      "event_id": "evt_duplicate_001",
+      "type": "objective.created",
+      "occurred_at": "2026-04-22T00:30:00Z"
+    }
+  ],
+  "expected_terminal_aggregate_state": {
+    "objective_status": "ready",
+    "duplicate_commands_suppressed": 1
+  },
+  "expected_projection_state": {
+    "active_runs": 0,
+    "dedupe_hits": 1
+  },
+  "expected_invariants": [
+    "idempotency_key_suppresses_duplicate_transition",
+    "no_duplicate_event_emission"
+  ]
+}

--- a/tests/golden/kernel/happy-path.json
+++ b/tests/golden/kernel/happy-path.json
@@ -1,0 +1,47 @@
+{
+  "trace_id": "kernel/happy-path/v1",
+  "schema_version": 1,
+  "scenario_name": "happy_path",
+  "seed_state": {
+    "objective_id": "obj_happy_001",
+    "objective_status": "planned"
+  },
+  "commands": [
+    {
+      "command_id": "cmd_happy_001",
+      "type": "objective.accepted",
+      "issued_at": "2026-04-22T00:00:00Z"
+    },
+    {
+      "command_id": "cmd_happy_002",
+      "type": "work_item.dispatch",
+      "issued_at": "2026-04-22T00:00:05Z"
+    }
+  ],
+  "expected_events": [
+    {
+      "event_id": "evt_happy_001",
+      "type": "objective.created",
+      "occurred_at": "2026-04-22T00:00:00Z"
+    },
+    {
+      "event_id": "evt_happy_002",
+      "type": "run.completed.valid_success",
+      "occurred_at": "2026-04-22T00:01:00Z"
+    }
+  ],
+  "expected_terminal_aggregate_state": {
+    "objective_status": "completed",
+    "work_item_status": "completed",
+    "run_status": "valid_success"
+  },
+  "expected_projection_state": {
+    "github_issue_state": "closed",
+    "pending_approvals": 0,
+    "active_runs": 0
+  },
+  "expected_invariants": [
+    "single_active_lease",
+    "no_downstream_without_valid_success"
+  ]
+}

--- a/tests/golden/kernel/known-loop-prevention.json
+++ b/tests/golden/kernel/known-loop-prevention.json
@@ -1,0 +1,41 @@
+{
+  "trace_id": "kernel/known-loop-prevention/v1",
+  "schema_version": 1,
+  "scenario_name": "known_loop_prevention",
+  "seed_state": {
+    "objective_id": "obj_loop_001",
+    "objective_status": "in_progress"
+  },
+  "commands": [
+    {
+      "command_id": "cmd_loop_001",
+      "type": "work_item.redispatch_attempt",
+      "issued_at": "2026-04-22T01:20:00Z"
+    }
+  ],
+  "expected_events": [
+    {
+      "event_id": "evt_loop_001",
+      "type": "run.awaiting_verification",
+      "occurred_at": "2026-04-22T01:20:00Z"
+    },
+    {
+      "event_id": "evt_loop_002",
+      "type": "work_item.escalated.no_new_causal_input",
+      "occurred_at": "2026-04-22T01:20:05Z"
+    }
+  ],
+  "expected_terminal_aggregate_state": {
+    "work_item_status": "escalated",
+    "run_status": "awaiting_verification",
+    "redispatch_count": 0
+  },
+  "expected_projection_state": {
+    "active_runs": 0,
+    "operator_attention_required": true
+  },
+  "expected_invariants": [
+    "no_redispatch_without_new_causal_input",
+    "terminal_blocked_or_escalated"
+  ]
+}

--- a/tests/golden/kernel/permanent-validation-failure.json
+++ b/tests/golden/kernel/permanent-validation-failure.json
@@ -1,0 +1,41 @@
+{
+  "trace_id": "kernel/permanent-validation-failure/v1",
+  "schema_version": 1,
+  "scenario_name": "permanent_validation_failure",
+  "seed_state": {
+    "objective_id": "obj_invalid_001",
+    "objective_status": "ready"
+  },
+  "commands": [
+    {
+      "command_id": "cmd_invalid_001",
+      "type": "work_item.dispatch",
+      "issued_at": "2026-04-22T00:50:00Z"
+    }
+  ],
+  "expected_events": [
+    {
+      "event_id": "evt_invalid_001",
+      "type": "task_result.invalid_output",
+      "occurred_at": "2026-04-22T00:50:20Z"
+    },
+    {
+      "event_id": "evt_invalid_002",
+      "type": "work_item.blocked",
+      "occurred_at": "2026-04-22T00:50:21Z"
+    }
+  ],
+  "expected_terminal_aggregate_state": {
+    "work_item_status": "blocked",
+    "run_status": "invalid_output",
+    "retry_count": 0
+  },
+  "expected_projection_state": {
+    "active_runs": 0,
+    "block_reason": "invalid_output"
+  },
+  "expected_invariants": [
+    "invalid_output_never_triggers_downstream_work",
+    "no_automatic_retry_after_schema_failure"
+  ]
+}

--- a/tests/golden/kernel/projection-drift.json
+++ b/tests/golden/kernel/projection-drift.json
@@ -1,0 +1,40 @@
+{
+  "trace_id": "kernel/projection-drift/v1",
+  "schema_version": 1,
+  "scenario_name": "projection_drift",
+  "seed_state": {
+    "objective_id": "obj_drift_001",
+    "objective_status": "in_progress"
+  },
+  "commands": [
+    {
+      "command_id": "cmd_drift_001",
+      "type": "projection.reconcile",
+      "issued_at": "2026-04-22T01:10:00Z"
+    }
+  ],
+  "expected_events": [
+    {
+      "event_id": "evt_drift_001",
+      "type": "projection.drift_detected",
+      "occurred_at": "2026-04-22T01:10:05Z"
+    },
+    {
+      "event_id": "evt_drift_002",
+      "type": "projection.rebuilt_from_ledger",
+      "occurred_at": "2026-04-22T01:10:20Z"
+    }
+  ],
+  "expected_terminal_aggregate_state": {
+    "projection_status": "healthy",
+    "objective_status": "in_progress"
+  },
+  "expected_projection_state": {
+    "drift_open": 0,
+    "last_successful_projection": "2026-04-22T01:10:20Z"
+  },
+  "expected_invariants": [
+    "runtime_ledger_is_authoritative",
+    "rebuild_restores_projection_without_mutating_runtime_truth"
+  ]
+}

--- a/tests/golden/kernel/transient-retry.json
+++ b/tests/golden/kernel/transient-retry.json
@@ -1,0 +1,46 @@
+{
+  "trace_id": "kernel/transient-retry/v1",
+  "schema_version": 1,
+  "scenario_name": "transient_retry",
+  "seed_state": {
+    "objective_id": "obj_retry_001",
+    "objective_status": "ready"
+  },
+  "commands": [
+    {
+      "command_id": "cmd_retry_001",
+      "type": "work_item.dispatch",
+      "issued_at": "2026-04-22T00:40:00Z"
+    }
+  ],
+  "expected_events": [
+    {
+      "event_id": "evt_retry_001",
+      "type": "run.failed.transient",
+      "occurred_at": "2026-04-22T00:40:30Z"
+    },
+    {
+      "event_id": "evt_retry_002",
+      "type": "run.retry_scheduled",
+      "occurred_at": "2026-04-22T00:40:31Z"
+    },
+    {
+      "event_id": "evt_retry_003",
+      "type": "run.completed.valid_success",
+      "occurred_at": "2026-04-22T00:41:15Z"
+    }
+  ],
+  "expected_terminal_aggregate_state": {
+    "work_item_status": "completed",
+    "retry_count": 1,
+    "run_status": "valid_success"
+  },
+  "expected_projection_state": {
+    "active_runs": 0,
+    "last_retry_reason": "transient_failure"
+  },
+  "expected_invariants": [
+    "retry_budget_enforced",
+    "retry_keeps_same_work_item_identity"
+  ]
+}


### PR DESCRIPTION
## Summary
- define the M7 alpha-readiness contract package under docs/alpha-readiness
- add a real replay-regression CI workflow plus fixture validation script
- seed canonical golden traces for alpha and wire branch protection bootstrap to require the new check

## Validation
- pnpm check:repo
- pnpm check:replay

Closes #39
Closes #40
Closes #41
Closes #42
Closes #43
