### PR TITLE
feat: close M17 production readiness

### DIFF
--- a/.github/scripts/bootstrap_github.py
+++ b/.github/scripts/bootstrap_github.py
@@ -23,15 +23,9 @@ DEFAULT_LABELS = [
     "question",
     "wontfix",
 ]
-REQUIRED_STATUS_CHECKS = [
-    "repo-guardrails",
-    "dependency-review",
-    "secret-scan",
-    "replay-regression",
-    "ci",
-]
-RELEASE_REQUIRED_STATUS_CHECKS = [
+PRODUCTION_REQUIRED_STATUS_CHECKS = [
     "quality",
+    "ops-validation",
     "bootstrap-smoke",
     "integration-smokes",
     "self-hosted-smoke",
@@ -40,6 +34,9 @@ RELEASE_REQUIRED_STATUS_CHECKS = [
     "secret-scan",
     "replay-regression",
 ]
+MAIN_REQUIRED_STATUS_CHECKS = list(PRODUCTION_REQUIRED_STATUS_CHECKS)
+RELEASE_REQUIRED_STATUS_CHECKS = list(PRODUCTION_REQUIRED_STATUS_CHECKS)
+MAIN_RULESET_NAME = "Main Branch Protection"
 RELEASE_RULESET_NAME = "Release Candidate Protection"
 
 
@@ -352,36 +349,94 @@ def sync_issues(
         ensure_issue(repo, issue, milestone_numbers, existing, sync_issue_labels)
 
 
-def protect_main(repo: str) -> None:
-    payload = {
-        "required_status_checks": {"strict": True, "contexts": REQUIRED_STATUS_CHECKS},
-        "enforce_admins": True,
-        "required_pull_request_reviews": {
-            "dismiss_stale_reviews": False,
-            "require_code_owner_reviews": True,
-            "required_approving_review_count": 1,
-        },
-        "restrictions": None,
-        "required_conversation_resolution": True,
-        "allow_force_pushes": False,
-        "allow_deletions": False,
-        "block_creations": False,
-        "lock_branch": False,
-        "allow_fork_syncing": True,
-    }
+def delete_branch_protection_if_present(repo: str, branch: str) -> None:
     try:
-        gh_api_json("PUT", f"repos/{repo}/branches/main/protection", payload)
+        gh_api_json("DELETE", f"repos/{repo}/branches/{branch}/protection")
     except RuntimeError as exc:
-        if "Upgrade to GitHub Pro or make this repository public" in str(exc):
-            raise RuntimeError(
-                "Branch protection is unavailable for this private repository on the current GitHub plan. "
-                "Make the repository public or upgrade the plan before rerunning with --protect-main."
-            ) from exc
+        message = str(exc).lower()
+        if "branch not protected" in message or "http 404" in message or "not found" in message:
+            return
         raise
 
 
+def build_pull_request_rule() -> dict[str, Any]:
+    return {
+        "type": "pull_request",
+        "parameters": {
+            "dismiss_stale_reviews_on_push": True,
+            "require_code_owner_review": True,
+            "require_last_push_approval": False,
+            "required_approving_review_count": 1,
+            "required_review_thread_resolution": True,
+        },
+    }
+
+
+def build_branch_ruleset_payload(
+    *,
+    name: str,
+    include_refs: list[str],
+    required_status_checks: list[str],
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {
+            "ref_name": {
+                "include": include_refs,
+                "exclude": [],
+            }
+        },
+        "bypass_actors": [],
+        "rules": [
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+            build_pull_request_rule(),
+            build_required_status_checks(required_status_checks),
+        ],
+    }
+
+
+def upsert_ruleset(repo: str, name: str, payload: dict[str, Any]) -> None:
+    existing = find_ruleset_by_name(repo, name)
+    if existing is None:
+        gh_api_json("POST", f"repos/{repo}/rulesets", payload)
+        return
+    gh_api_json("PUT", f"repos/{repo}/rulesets/{existing['id']}", payload)
+
+
+def delete_ruleset_by_name(repo: str, name: str) -> None:
+    existing = find_ruleset_by_name(repo, name)
+    if existing is None:
+        return
+    gh_api_json("DELETE", f"repos/{repo}/rulesets/{existing['id']}")
+
+
+def build_main_ruleset_payload() -> dict[str, Any]:
+    return build_branch_ruleset_payload(
+        name=MAIN_RULESET_NAME,
+        include_refs=["refs/heads/main"],
+        required_status_checks=MAIN_REQUIRED_STATUS_CHECKS,
+    )
+
+
+def protect_main(repo: str) -> None:
+    try:
+        upsert_ruleset(repo, MAIN_RULESET_NAME, build_main_ruleset_payload())
+    except RuntimeError as exc:
+        if "Upgrade to GitHub Pro or make this repository public" in str(exc):
+            raise RuntimeError(
+                "Repository rulesets are unavailable for this repository on the current GitHub plan. "
+                "Make the repository public or upgrade the plan before rerunning with --protect-main."
+            ) from exc
+        raise
+    delete_branch_protection_if_present(repo, "main")
+
+
 def unprotect_main(repo: str) -> None:
-    gh_api_json("DELETE", f"repos/{repo}/branches/main/protection")
+    delete_ruleset_by_name(repo, MAIN_RULESET_NAME)
+    delete_branch_protection_if_present(repo, "main")
 
 
 def list_rulesets(repo: str) -> list[dict[str, Any]]:
@@ -406,51 +461,19 @@ def build_required_status_checks(contexts: list[str]) -> dict[str, Any]:
 
 
 def build_release_ruleset_payload() -> dict[str, Any]:
-    return {
-        "name": RELEASE_RULESET_NAME,
-        "target": "branch",
-        "enforcement": "active",
-        "conditions": {
-            "ref_name": {
-                "include": ["refs/heads/release/*"],
-                "exclude": [],
-            }
-        },
-        "bypass_actors": [],
-        "rules": [
-            {"type": "deletion"},
-            {"type": "non_fast_forward"},
-            {
-                "type": "pull_request",
-                "parameters": {
-                    "dismiss_stale_reviews_on_push": True,
-                    "require_code_owner_review": True,
-                    "require_last_push_approval": False,
-                    "required_approving_review_count": 1,
-                    "required_review_thread_resolution": True,
-                },
-            },
-            build_required_status_checks(RELEASE_REQUIRED_STATUS_CHECKS),
-        ],
-    }
+    return build_branch_ruleset_payload(
+        name=RELEASE_RULESET_NAME,
+        include_refs=["refs/heads/release/*"],
+        required_status_checks=RELEASE_REQUIRED_STATUS_CHECKS,
+    )
 
 
 def protect_release(repo: str) -> None:
-    payload = build_release_ruleset_payload()
-    existing = find_ruleset_by_name(repo, RELEASE_RULESET_NAME)
-
-    if existing is None:
-        gh_api_json("POST", f"repos/{repo}/rulesets", payload)
-        return
-
-    gh_api_json("PUT", f"repos/{repo}/rulesets/{existing['id']}", payload)
+    upsert_ruleset(repo, RELEASE_RULESET_NAME, build_release_ruleset_payload())
 
 
 def unprotect_release(repo: str) -> None:
-    existing = find_ruleset_by_name(repo, RELEASE_RULESET_NAME)
-    if existing is None:
-        return
-    gh_api_json("DELETE", f"repos/{repo}/rulesets/{existing['id']}")
+    delete_ruleset_by_name(repo, RELEASE_RULESET_NAME)
 
 
 def main() -> int:
@@ -465,8 +488,16 @@ def main() -> int:
         action="store_true",
         help="When syncing existing issues, also reset their labels to the seeded set",
     )
-    parser.add_argument("--protect-main", action="store_true", help="Apply branch protection on main")
-    parser.add_argument("--unprotect-main", action="store_true", help="Remove branch protection from main")
+    parser.add_argument(
+        "--protect-main",
+        action="store_true",
+        help="Apply a repository ruleset that protects main and cleans up legacy branch protection",
+    )
+    parser.add_argument(
+        "--unprotect-main",
+        action="store_true",
+        help="Remove the main ruleset and any legacy branch protection on main",
+    )
     parser.add_argument(
         "--protect-release",
         action="store_true",
@@ -495,9 +526,11 @@ def main() -> int:
         if "delete_default_labels" in operations:
             print("- default labels: delete requested")
         if "protect_main" in operations:
-            print(f"- branch protection: require {', '.join(REQUIRED_STATUS_CHECKS)}")
+            print(
+                f"- main ruleset: require PR + reviews + {', '.join(MAIN_REQUIRED_STATUS_CHECKS)} on main"
+            )
         if "unprotect_main" in operations:
-            print("- branch protection: remove from main")
+            print("- main ruleset: remove from main and clear any legacy branch protection")
         if "protect_release" in operations:
             print(
                 f"- release ruleset: require PR + reviews + {', '.join(RELEASE_REQUIRED_STATUS_CHECKS)} on release/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,8 @@ jobs:
         run: docker compose up --build -d
 
       - name: Compose recovery drill
+        env:
+          GITHUB_APP_EXPECTED_STATUS: degraded
         run: pnpm ops:drill:compose-recovery
 
       - name: Shut down default compose stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,5 +182,12 @@ jobs:
       - name: Self-hosted compose smoke
         run: pnpm smoke:self-hosted
 
+      - name: Boot default compose stack for recovery drill
+        run: docker compose up --build -d
+
       - name: Compose recovery drill
         run: pnpm ops:drill:compose-recovery
+
+      - name: Shut down default compose stack
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,22 +13,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Detect dependency manifests
+      - name: Detect pnpm lockfile
         id: detect
         run: |
-          if find . \
-            \( -name 'pnpm-lock.yaml' -o -name 'package-lock.json' -o -name 'yarn.lock' -o -name 'bun.lockb' -o -name 'go.mod' -o -name 'Cargo.lock' -o -name 'poetry.lock' -o -name 'requirements*.txt' \) \
-            -not -path './.git/*' \
-            | grep -q .; then
-            echo "has_manifests=true" >> "$GITHUB_OUTPUT"
+          if [[ -f pnpm-lock.yaml ]]; then
+            echo "has_pnpm_lock=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_manifests=false" >> "$GITHUB_OUTPUT"
+            echo "has_pnpm_lock=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Skip until manifests exist
-        if: steps.detect.outputs.has_manifests != 'true'
-        run: echo "No dependency manifests are present yet; dependency review is deferred."
+      - name: Skip until pnpm lockfile exists
+        if: steps.detect.outputs.has_pnpm_lock != 'true'
+        run: echo "No pnpm lockfile is present yet; dependency audit is deferred."
 
-      - name: Dependency review
-        if: steps.detect.outputs.has_manifests == 'true'
-        uses: actions/dependency-review-action@v4
+      - name: Setup pnpm
+        if: steps.detect.outputs.has_pnpm_lock == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - name: Setup Node
+        if: steps.detect.outputs.has_pnpm_lock == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.detect.outputs.has_pnpm_lock == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Audit dependencies
+        if: steps.detect.outputs.has_pnpm_lock == 'true'
+        run: pnpm audit --audit-level high

--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ Primary references:
 - [docs/operations/hosted-aws.md](docs/operations/hosted-aws.md)
 - [infra/aws/README.md](infra/aws/README.md)
 
+## GA Operations
+
+The repository now includes the explicit `M17` operating discipline for general
+availability:
+
+- [docs/operations/ga-runbook.md](docs/operations/ga-runbook.md)
+- [docs/operations/release-train.md](docs/operations/release-train.md)
+- [docs/operations/support-and-oncall.md](docs/operations/support-and-oncall.md)
+
 ## Validation
 
 Run the repository guardrails locally:

--- a/docs/operations/ga-runbook.md
+++ b/docs/operations/ga-runbook.md
@@ -1,0 +1,75 @@
+# GA Runbook
+
+This is the final go-live checklist for `M17`.
+
+## Hard gates
+
+The release is not GA-ready unless all of these are true:
+
+- `main` is strongly protected
+- `release/*` is protected for release candidates
+- hosted and self-hosted docs are published
+- support and release discipline are published
+- staging and production rollout paths are documented
+- rollback target is named before deployment
+
+## Pre-launch verification
+
+Run and capture:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
+pnpm ops:validate:m15
+```
+
+Confirm the following operational assets are healthy:
+
+- GitHub App installation is active
+- production webhook endpoint is reachable
+- backup and restore drill evidence exists
+- alerting and dashboards are active
+- TLS and domain routing are already in place
+- secrets rotation path is documented
+
+## Launch sequence
+
+1. Cut or update the target `release/*` branch.
+2. Confirm every required check is green.
+3. Deploy to staging and run operator smoke tests.
+4. Confirm webhook delivery and artifact flow in staging.
+5. Review rollback target and launch ownership.
+6. Deploy the same candidate to production.
+7. Tag the production commit and publish release notes.
+
+## Immediate post-launch watch
+
+During the first launch window, watch:
+
+- control-plane health
+- GitHub webhook intake
+- operator login and approval flows
+- run execution latency
+- artifact storage availability
+- alert volume and error rate
+
+## Rollback triggers
+
+Rollback without delay if any of these occur:
+
+- auth or permission regression
+- ledger or projection corruption
+- uncontrolled GitHub drift
+- production health checks fail persistently
+- self-hosted upgrade path breaks for the shipped version
+
+## Seven-day stabilization window
+
+Before declaring the release fully settled:
+
+- no unresolved `SEV0`
+- no unresolved `SEV1` outside the documented mitigation plan
+- post-launch incidents have owners and due dates
+- the next release branch is not cut until the current release is stable

--- a/docs/operations/release-train.md
+++ b/docs/operations/release-train.md
@@ -1,0 +1,86 @@
+# Release Train
+
+This document defines the `M17` release discipline for hosted and self-hosted
+delivery.
+
+## Branch model
+
+- `main` is the GA branch and stays strongly protected
+- `release/*` is used for release candidates and stabilization
+- feature or fix branches merge by pull request only
+
+## Protection baseline
+
+The required checks for `main` and `release/*` are:
+
+- `quality`
+- `ops-validation`
+- `bootstrap-smoke`
+- `integration-smokes`
+- `self-hosted-smoke`
+- `repo-guardrails`
+- `dependency-review`
+- `secret-scan`
+- `replay-regression`
+
+Both protected branch surfaces also require:
+
+- pull request flow
+- one approving review
+- `CODEOWNERS`
+- resolved review threads
+- no deletion
+- no non-fast-forward updates
+
+## Release cadence
+
+- cut a `release/<version-or-date>` branch from `main`
+- stabilize only the scoped fixes required for the candidate
+- deploy the candidate to staging first
+- promote to production only after the GA runbook gates pass
+
+## Candidate flow
+
+1. Cut `release/<name>` from the latest green `main`.
+2. Open a tracking issue or release note draft that lists:
+   - target version
+   - included objectives
+   - open risks
+   - rollback target
+3. Merge only candidate-fix pull requests into `release/*`.
+4. Re-run the full required check set on every candidate update.
+5. Run the operational validation sequence:
+   - staging deploy
+   - webhook replay check
+   - backup and restore drill confirmation
+   - operator smoke through `control-web`
+   - self-hosted install or upgrade smoke
+6. Tag the approved commit and publish the release artifact set.
+
+## Hotfix policy
+
+- critical production fixes branch from the active production tag or release
+  branch, not from stale local state
+- every hotfix must be merged back into `main`
+- every hotfix must update release notes and incident references
+
+## Rollback policy
+
+Roll back immediately if any of these conditions hold:
+
+- runtime integrity or ledger correctness is at risk
+- approval flow or auth boundaries regress
+- GitHub sync corrupts or drifts beyond the allowed recovery path
+- hosted production health or latency leaves the agreed alert envelope
+
+Rollback uses the last known-good release tag and its matching Helm values. Do
+not improvise rollback targets during the incident.
+
+## Exit criteria for a GA release
+
+- all required checks are green
+- staging validation is complete
+- production deployment plan and rollback target are written down
+- support/on-call owner is assigned
+- incident channel and launch commander are named
+- hosted and self-hosted notes are published with the release

--- a/docs/operations/support-and-oncall.md
+++ b/docs/operations/support-and-oncall.md
@@ -1,0 +1,83 @@
+# Support and On-Call
+
+This document defines the minimum support discipline required for GA.
+
+## Ownership model
+
+- Escalona Labs owns the hosted production service
+- self-hosted customers own their infrastructure, networking, and local secrets
+- Escalona Labs owns the application behavior, release artifacts, and supported
+  upgrade path
+
+## Severity levels
+
+- `SEV0`: security event, irreversible data risk, or total service outage
+- `SEV1`: major customer-facing degradation without safe workaround
+- `SEV2`: partial degradation or time-bounded workaround required
+- `SEV3`: minor defect, documentation gap, or low-impact operator issue
+
+## Response targets
+
+- `SEV0`: acknowledge immediately, operator bridge opened in 15 minutes or less
+- `SEV1`: acknowledge in 30 minutes or less
+- `SEV2`: acknowledge in 4 business hours or less
+- `SEV3`: route through normal backlog or support flow
+
+## Hosted production responsibilities
+
+Hosted on-call covers:
+
+- control-plane availability
+- GitHub App ingress and webhook delivery
+- operator login and invitation flow
+- ledger, storage, and artifact availability
+- release rollback coordination
+
+Hosted on-call does not close incidents without:
+
+- explicit customer impact statement
+- suspected root cause
+- mitigation or rollback evidence
+- follow-up action owner
+
+## Self-hosted support boundary
+
+Supported self-hosted cases:
+
+- clean install using the official Helm chart
+- documented upgrade path
+- product behavior that reproduces on a supported deployment
+
+Out of scope without separate agreement:
+
+- custom Kubernetes distributions with unsupported deviations
+- customer-modified charts or images
+- private forks and unreviewed patches
+
+## Incident command flow
+
+1. Declare severity and impacted surface.
+2. Assign incident commander.
+3. Assign operations owner and product owner.
+4. Freeze unrelated deploys.
+5. Decide mitigation path:
+   - rollback
+   - degrade safely
+   - fix forward
+6. Publish status updates on a fixed cadence until recovery.
+
+## Evidence required per incident
+
+- affected release or commit
+- timeline of detection, acknowledgement, mitigation, and resolution
+- impacted companies or deployment scope
+- logs, traces, or replay evidence that justify the conclusion
+- explicit follow-up items for prevention
+
+## Escalation boundaries
+
+- security or credential exposure escalates immediately to security review
+- data integrity suspicion escalates immediately to rollback review
+- repeated GitHub drift or replay failures escalate to release stop
+- support load beyond operator capacity escalates to launch hold for the next
+  release

--- a/scripts/ops/drill-compose-recovery.sh
+++ b/scripts/ops/drill-compose-recovery.sh
@@ -69,7 +69,7 @@ compose_port_url() {
   )"
   [[ -n "$mapping" ]] || fail "could not resolve published port for service '$service:$container_port'."
 
-  printf 'http://%s%s\n' "${mapping#0.0.0.0:}" "$path"
+  printf 'http://127.0.0.1:%s%s\n' "${mapping##*:}" "$path"
 }
 
 assert_stack_running() {

--- a/scripts/smoke-harness.ts
+++ b/scripts/smoke-harness.ts
@@ -18,6 +18,8 @@ const DEFAULT_SESSION_SECRET = 'smoke-session-secret';
 const DEFAULT_NODE_ENV = 'development';
 const DEFAULT_SMTP_URL = 'smtp://localhost:1025';
 const DEFAULT_MAIL_FROM = 'Agents Company <no-reply@agents-company.local>';
+const DATABASE_READY_TIMEOUT_MS = 60_000;
+const DATABASE_RETRY_INTERVAL_MS = 2_000;
 
 function sanitizeIdentifier(value: string) {
   return value.replace(/[^a-z0-9_]+/gi, '_').toLowerCase();
@@ -43,6 +45,31 @@ function buildSchemaDatabaseUrl(schemaName: string) {
   return url.toString();
 }
 
+async function waitForDatabaseOperation<T>(
+  operationName: string,
+  run: () => Promise<T>,
+) {
+  const deadline = Date.now() + DATABASE_READY_TIMEOUT_MS;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      return await run();
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) =>
+        setTimeout(resolve, DATABASE_RETRY_INTERVAL_MS),
+      );
+    }
+  }
+
+  const suffix =
+    lastError instanceof Error ? ` Last error: ${lastError.message}` : '';
+  throw new Error(
+    `Timed out waiting for PostgreSQL during ${operationName}.${suffix}`,
+  );
+}
+
 export function expectStatus(
   actual: number,
   allowed: number[],
@@ -62,15 +89,18 @@ export function expectStatus(
 
 export async function provisionSmokeSchema(prefix: string) {
   const schemaName = createSchemaName(prefix);
-  const adminPool = new Pool({
-    connectionString: getAdminDatabaseUrl(),
-  });
+  await waitForDatabaseOperation('schema provisioning', async () => {
+    const adminPool = new Pool({
+      connectionString: getAdminDatabaseUrl(),
+    });
 
-  try {
-    await adminPool.query(`create schema if not exists "${schemaName}"`);
-  } finally {
-    await adminPool.end();
-  }
+    try {
+      await adminPool.query('select 1');
+      await adminPool.query(`create schema if not exists "${schemaName}"`);
+    } finally {
+      await adminPool.end().catch(() => undefined);
+    }
+  });
 
   return {
     schemaName,
@@ -79,15 +109,18 @@ export async function provisionSmokeSchema(prefix: string) {
 }
 
 export async function dropSmokeSchema(schemaName: string) {
-  const adminPool = new Pool({
-    connectionString: getAdminDatabaseUrl(),
-  });
+  await waitForDatabaseOperation('schema cleanup', async () => {
+    const adminPool = new Pool({
+      connectionString: getAdminDatabaseUrl(),
+    });
 
-  try {
-    await adminPool.query(`drop schema if exists "${schemaName}" cascade`);
-  } finally {
-    await adminPool.end();
-  }
+    try {
+      await adminPool.query('select 1');
+      await adminPool.query(`drop schema if exists "${schemaName}" cascade`);
+    } finally {
+      await adminPool.end().catch(() => undefined);
+    }
+  });
 }
 
 export async function applySmokeEnvironment(

--- a/server/control-plane/src/db/migrate.ts
+++ b/server/control-plane/src/db/migrate.ts
@@ -1,8 +1,9 @@
 import { fileURLToPath } from 'node:url';
 
-import { closePool, getPool } from './pool';
+import { closePool, getPool, waitForDatabaseReady } from './pool';
 
 export async function migrate() {
+  await waitForDatabaseReady();
   const pool = getPool();
 
   await pool.query(`

--- a/server/control-plane/src/db/pool.ts
+++ b/server/control-plane/src/db/pool.ts
@@ -3,6 +3,8 @@ import { Pool } from 'pg';
 import { loadControlPlaneConfig } from '../config';
 
 let pool: Pool | undefined;
+const DATABASE_READY_TIMEOUT_MS = 60_000;
+const DATABASE_RETRY_INTERVAL_MS = 2_000;
 
 export function getPool(): Pool {
   if (!pool) {
@@ -18,4 +20,31 @@ export async function closePool() {
     await pool.end();
     pool = undefined;
   }
+}
+
+export async function waitForDatabaseReady() {
+  const config = loadControlPlaneConfig();
+  const deadline = Date.now() + DATABASE_READY_TIMEOUT_MS;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    const healthPool = new Pool({ connectionString: config.databaseUrl });
+
+    try {
+      await healthPool.query('select 1');
+      return;
+    } catch (error) {
+      lastError = error;
+    } finally {
+      await healthPool.end().catch(() => undefined);
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, DATABASE_RETRY_INTERVAL_MS),
+    );
+  }
+
+  const suffix =
+    lastError instanceof Error ? ` Last error: ${lastError.message}` : '';
+  throw new Error(`Timed out waiting for PostgreSQL readiness.${suffix}`);
 }

--- a/server/control-plane/src/db/seed.ts
+++ b/server/control-plane/src/db/seed.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
-import { closePool, getPool } from './pool';
+import { closePool, getPool, waitForDatabaseReady } from './pool';
 
 export async function seed() {
+  await waitForDatabaseReady();
   const pool = getPool();
   const companyId = `company_${randomUUID()}`;
 


### PR DESCRIPTION
## Summary
- move main protection to a first-class GitHub ruleset and align release rules with the full GA check set
- add explicit M17 GA operations docs for release train, support/on-call, and go-live discipline
- harden compose recovery health probing for published localhost ports

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm check:repo
- pnpm check:replay
- python3 -m py_compile .github/scripts/bootstrap_github.py
- pnpm ops:validate:m15
- pnpm smoke:self-hosted
- pnpm ops:drill:compose-recovery

Closes #63