### PR TITLE
Finish M15-M18 release evidence and immutable artifacts

### DIFF
--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -1,0 +1,84 @@
+name: release-evidence
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version or tag. Example: v0.1.0
+        required: true
+        type: string
+      release_branch:
+        description: Release branch name. Example: release/v0.1.0
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+  checks: read
+  actions: read
+
+jobs:
+  evidence:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve release metadata
+        id: release_meta
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION_INPUT="${{ inputs.version }}"
+            BRANCH_INPUT="${{ inputs.release_branch }}"
+          else
+            VERSION_INPUT="${{ github.event.release.tag_name }}"
+            BRANCH_INPUT="${{ github.event.release.target_commitish }}"
+          fi
+
+          if [[ "$VERSION_INPUT" != v* ]]; then
+            VERSION_TAG="v$VERSION_INPUT"
+          else
+            VERSION_TAG="$VERSION_INPUT"
+          fi
+
+          if [[ -z "$BRANCH_INPUT" ]]; then
+            BRANCH_INPUT="release/$VERSION_TAG"
+          fi
+
+          echo "version_tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
+          echo "release_branch=$BRANCH_INPUT" >> "$GITHUB_OUTPUT"
+
+      - name: Build release evidence
+        run: >
+          pnpm exec tsx scripts/build-release-evidence.ts
+          --repo "${{ github.repository }}"
+          --version "${{ steps.release_meta.outputs.version_tag }}"
+          --release-branch "${{ steps.release_meta.outputs.release_branch }}"
+          --output-dir "artifacts/releases/${{ steps.release_meta.outputs.version_tag }}"
+
+      - name: Upload release evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-evidence-${{ steps.release_meta.outputs.version_tag }}
+          path: artifacts/releases/${{ steps.release_meta.outputs.version_tag }}

--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ availability:
 - [docs/operations/release-train.md](docs/operations/release-train.md)
 - [docs/operations/support-and-oncall.md](docs/operations/support-and-oncall.md)
 
+## M18 Launch Evidence
+
+The repository now includes the final evidence and activation pack used to ship
+the first production candidate without relying on chat memory:
+
+- [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md)
+- [docs/operations/hosted-rotation-and-drills.md](docs/operations/hosted-rotation-and-drills.md)
+- [docs/operations/monitoring-dashboards.md](docs/operations/monitoring-dashboards.md)
+- [ops/monitoring/grafana/agents-company-overview.json](ops/monitoring/grafana/agents-company-overview.json)
+
 ## Validation
 
 Run the repository guardrails locally:
@@ -120,8 +130,9 @@ Run the repository guardrails locally:
 ```bash
 pnpm check:repo
 pnpm check:replay
-pnpm ci
+pnpm run ci
 pnpm ops:validate:m15
+pnpm release:evidence -- --version v0.1.0 --release-branch release/v0.1.0
 ```
 
 ## Security

--- a/apps/control-web/package.json
+++ b/apps/control-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalonalabs/control-web",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/charts/agents-company/Chart.yaml
+++ b/charts/agents-company/Chart.yaml
@@ -3,5 +3,4 @@ name: agents-company
 description: Minimal self-hosted foundation for Agents Company app surfaces
 type: application
 version: 0.1.0
-appVersion: "0.0.0"
-
+appVersion: "0.1.0"

--- a/charts/agents-company/values-production.yaml
+++ b/charts/agents-company/values-production.yaml
@@ -32,7 +32,7 @@ controlPlane:
   replicaCount: 3
   image:
     repository: 123456789012.dkr.ecr.us-east-1.amazonaws.com/agents-company-production/control-plane
-    tag: production
+    tag: v0.1.0
   serviceAccount:
     create: true
     name: agents-company-control-plane
@@ -78,7 +78,7 @@ githubApp:
   replicaCount: 3
   image:
     repository: 123456789012.dkr.ecr.us-east-1.amazonaws.com/agents-company-production/github-app
-    tag: production
+    tag: v0.1.0
   serviceAccount:
     create: true
     name: agents-company-github-app
@@ -117,7 +117,7 @@ controlWeb:
   replicaCount: 3
   image:
     repository: 123456789012.dkr.ecr.us-east-1.amazonaws.com/agents-company-production/control-web
-    tag: production
+    tag: v0.1.0
   autoscaling:
     enabled: true
     minReplicas: 3

--- a/charts/agents-company/values-staging.yaml
+++ b/charts/agents-company/values-staging.yaml
@@ -28,7 +28,7 @@ controlPlane:
   replicaCount: 2
   image:
     repository: 123456789012.dkr.ecr.us-east-1.amazonaws.com/agents-company-staging/control-plane
-    tag: staging
+    tag: v0.1.0
   serviceAccount:
     create: true
     name: agents-company-control-plane
@@ -74,7 +74,7 @@ githubApp:
   replicaCount: 2
   image:
     repository: 123456789012.dkr.ecr.us-east-1.amazonaws.com/agents-company-staging/github-app
-    tag: staging
+    tag: v0.1.0
   serviceAccount:
     create: true
     name: agents-company-github-app
@@ -113,7 +113,7 @@ controlWeb:
   replicaCount: 2
   image:
     repository: 123456789012.dkr.ecr.us-east-1.amazonaws.com/agents-company-staging/control-web
-    tag: staging
+    tag: v0.1.0
   autoscaling:
     enabled: true
     minReplicas: 2

--- a/docs/backlog/initial-backlog.md
+++ b/docs/backlog/initial-backlog.md
@@ -116,3 +116,7 @@
 ## M17 General Availability
 
 - `AC-1701` Deliver M17 General Availability
+
+## M18 Launch Evidence and Activation
+
+- `AC-1801` Deliver M18 Launch Evidence and Activation

--- a/docs/backlog/runtime-seed.json
+++ b/docs/backlog/runtime-seed.json
@@ -39,6 +39,10 @@
     {
       "title": "M17 General Availability",
       "description": "Definition of Done: hosted and self-hosted releases are customer-ready, supportable, and protected by final release discipline."
+    },
+    {
+      "title": "M18 Launch Evidence and Activation",
+      "description": "Definition of Done: immutable release artifacts, release evidence, monitoring dashboards, and hosted cutover procedures are published for the first production candidate."
     }
   ],
   "issues": [
@@ -341,6 +345,21 @@
       ],
       "depends_on": ["AC-1601"],
       "body": "Outcome:\\nClose the final production readiness gap, restore hard GitHub protections, publish hosted and self-hosted docs, and open general availability.\\n\\nValidation:\\nThe product is supportable, protected, and customer-ready for GA."
+    },
+    {
+      "key": "AC-1801",
+      "title": "Deliver M18 Launch Evidence and Activation",
+      "milestone": "M18 Launch Evidence and Activation",
+      "labels": [
+        "type:epic",
+        "area:release",
+        "P0",
+        "size:L",
+        "state:ready",
+        "track:mvp"
+      ],
+      "depends_on": ["AC-1701"],
+      "body": "Outcome:\\nPublish immutable release artifacts, evidence bundles, dashboard assets, and hosted rotation or drill procedures so the first production candidate is auditable and handoff-safe.\\n\\nValidation:\\nA tagged release candidate can generate a release evidence bundle, the dashboard pack exists in-repo, image tags are immutable, and hosted cutover procedures are explicit."
     }
   ]
 }

--- a/docs/operations/ga-runbook.md
+++ b/docs/operations/ga-runbook.md
@@ -23,6 +23,7 @@ pnpm typecheck
 pnpm test
 pnpm build
 pnpm ops:validate:m15
+pnpm release:evidence -- --version v0.1.0 --release-branch release/v0.1.0
 ```
 
 Confirm the following operational assets are healthy:

--- a/docs/operations/hosted-rotation-and-drills.md
+++ b/docs/operations/hosted-rotation-and-drills.md
@@ -1,0 +1,65 @@
+# Hosted Rotation and Drills
+
+This document turns the hosted `M15` to `M18` operational promises into a
+repeatable checklist.
+
+## Secrets that must rotate
+
+- session secret for `control-plane`
+- internal API token shared between `control-plane` and `github-app`
+- GitHub App webhook secret
+- GitHub App private key
+- outbound mail credentials
+- database password stored in the hosted runtime secret
+
+## Rotation cadence
+
+- session and internal API secrets: every 90 days or immediately after exposure
+- GitHub webhook secret: every 90 days or after webhook validation failure
+- GitHub App private key: every 90 days or immediately after suspected leakage
+- mail credentials: every 180 days or after provider incident
+- database password: every 180 days and before major compliance reviews
+
+## Hosted rotation procedure
+
+1. Generate the new secret material outside the cluster.
+2. Update the AWS Secrets Manager runtime secret.
+3. Trigger a staged rollout in staging first.
+4. Confirm `/health`, `/metrics`, and webhook delivery stay green.
+5. Promote the same change to production.
+6. Capture the rotation timestamp, owner, and validation evidence in the active
+   release evidence folder.
+
+## Reliability drills that must exist before a cutover
+
+- Postgres backup drill
+- Postgres restore drill
+- self-hosted compose recovery drill
+- GitHub webhook replay drill
+- release rollback drill using the last known-good immutable tag
+
+## Required evidence per drill
+
+- the exact release tag under test
+- operator or incident owner
+- start and end timestamps
+- commands or automation path used
+- observed outcome
+- rollback or remediation notes if the drill exposed a gap
+
+## Release artifact location
+
+Every production candidate stores its evidence under:
+
+`artifacts/releases/<tag>/`
+
+At minimum that folder must contain:
+
+- `readiness.json`
+- `SUMMARY.md`
+- a note or attachment reference for any hosted drill executed outside the repo
+
+## Cutover rule
+
+No hosted cutover is approved if any required rotation or drill is missing,
+stale, or only described verbally.

--- a/docs/operations/monitoring-dashboards.md
+++ b/docs/operations/monitoring-dashboards.md
@@ -1,0 +1,38 @@
+# Monitoring Dashboards
+
+The Grafana baseline for the first production candidate lives in:
+
+- [ops/monitoring/grafana/agents-company-overview.json](../../ops/monitoring/grafana/agents-company-overview.json)
+
+## Minimum dashboard surfaces
+
+- control-plane availability
+- GitHub App availability
+- auth readiness
+- accepted webhook volume
+- rejected webhook volume
+- operator workload counts
+- cohort counts for internal alpha and controlled beta
+
+## Launch usage
+
+Use the dashboard pack in three places:
+
+1. Pre-release staging validation
+2. First production cutover watch window
+3. Incident review when rollback is being considered
+
+## Data sources
+
+- Prometheus scrape for `control-plane`
+- Prometheus scrape for `github-app`
+
+The dashboard assumes the default Prometheus datasource variable
+`${DS_PROMETHEUS}` and the metrics currently emitted by the two backend
+services.
+
+## Ownership
+
+- Release owner confirms the dashboard pack matches the shipped metrics.
+- On-call uses the same dashboard JSON during the first seven-day stabilization
+  window.

--- a/docs/operations/release-train.md
+++ b/docs/operations/release-train.md
@@ -55,7 +55,11 @@ Both protected branch surfaces also require:
    - backup and restore drill confirmation
    - operator smoke through `control-web`
    - self-hosted install or upgrade smoke
-6. Tag the approved commit and publish the release artifact set.
+6. Generate the release evidence bundle from the candidate branch.
+7. Tag the approved commit with an immutable semver tag and publish the release artifact set.
+
+Mutable aliases such as `staging` or `production` are not release artifacts.
+Staging and production values files must point to immutable semver tags only.
 
 ## Hotfix policy
 

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,31 @@
+# Release v0.1.0
+
+`v0.1.0` is the first production candidate for Agents Company by Escalona Labs.
+
+## What this release contains
+
+- deterministic kernel, replay, and loop-prevention coverage
+- GitHub App runtime, reconciliation, and drift detection
+- control plane API plus operator web UI
+- memory and provenance layer
+- multi-company and self-hosted foundations
+- hosted AWS infrastructure as code and Helm packaging
+- GA runbook, release train, support model, and release evidence workflow
+
+## Operational notes
+
+- staging and production Helm values now use immutable `v0.1.0` image tags
+- ECR repositories are configured for immutable tags
+- release evidence is generated under `artifacts/releases/v0.1.0/`
+
+## Known external blockers
+
+- hosted AWS activation still requires applying the committed Terraform with a
+  real Escalona Labs AWS account
+- live hosted cutover evidence must be captured after that apply
+
+## Validation baseline
+
+- `pnpm run ci`
+- `pnpm ops:validate:m15`
+- `pnpm release:evidence -- --version v0.1.0 --release-branch release/v0.1.0`

--- a/docs/roadmap/platform-rebuild.md
+++ b/docs/roadmap/platform-rebuild.md
@@ -24,6 +24,7 @@ Build a new company-of-agents platform under the Escalona Labs brand with a dete
 - `M15 Production Infrastructure and Reliability`
 - `M16 Internal Alpha and Controlled Beta`
 - `M17 General Availability`
+- `M18 Launch Evidence and Activation`
 
 ## Non-negotiables
 
@@ -157,6 +158,13 @@ Build a new company-of-agents platform under the Escalona Labs brand with a dete
 - Support and release discipline are explicit
 - Product is customer-ready for GA
 
+### M18 Launch Evidence and Activation
+
+- Immutable release artifacts are enforced end to end
+- Release evidence is generated as a first-class artifact bundle
+- Monitoring dashboards are committed and referenced by operations
+- Hosted rotation and drill procedures are published for cutover handoff
+
 ## Build order
 
 1. Foundation and naming
@@ -171,3 +179,4 @@ Build a new company-of-agents platform under the Escalona Labs brand with a dete
 10. GitHub runtime integration
 11. Operator control plane
 12. Customer and production readiness
+13. Launch evidence and activation pack

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -397,7 +397,7 @@ resource "aws_ses_email_identity" "sender" {
 
 resource "aws_ecr_repository" "control_plane" {
   name                 = "${local.effective_name_prefix}/control-plane"
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "IMMUTABLE"
 
   image_scanning_configuration {
     scan_on_push = true
@@ -408,7 +408,7 @@ resource "aws_ecr_repository" "control_plane" {
 
 resource "aws_ecr_repository" "github_app" {
   name                 = "${local.effective_name_prefix}/github-app"
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "IMMUTABLE"
 
   image_scanning_configuration {
     scan_on_push = true
@@ -419,7 +419,7 @@ resource "aws_ecr_repository" "github_app" {
 
 resource "aws_ecr_repository" "control_web" {
   name                 = "${local.effective_name_prefix}/control-web"
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "IMMUTABLE"
 
   image_scanning_configuration {
     scan_on_push = true

--- a/ops/monitoring/grafana/agents-company-overview.json
+++ b/ops/monitoring/grafana/agents-company-overview.json
@@ -1,0 +1,385 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "agents_company_control_plane_up",
+          "refId": "A"
+        }
+      ],
+      "title": "Control Plane Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "agents_company_github_app_up",
+          "refId": "A"
+        }
+      ],
+      "title": "GitHub App Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "agents_company_control_plane_auth_session_ready",
+          "refId": "A"
+        }
+      ],
+      "title": "Session Auth Ready",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "agents_company_github_app_webhook_verification_ready",
+          "refId": "A"
+        }
+      ],
+      "title": "Webhook Verification Ready",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(agents_company_github_app_accepted_deliveries_total[5m])",
+          "legendFormat": "accepted",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(agents_company_github_app_rejected_deliveries_total[5m])",
+          "legendFormat": "rejected",
+          "refId": "B"
+        }
+      ],
+      "title": "Webhook Delivery Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "agents_company_control_plane_companies",
+          "legendFormat": "companies",
+          "refId": "A"
+        },
+        {
+          "expr": "agents_company_control_plane_companies_internal_alpha",
+          "legendFormat": "internal alpha",
+          "refId": "B"
+        },
+        {
+          "expr": "agents_company_control_plane_companies_controlled_beta",
+          "legendFormat": "controlled beta",
+          "refId": "C"
+        }
+      ],
+      "title": "Company Cohorts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 4
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "agents_company_control_plane_objectives",
+          "legendFormat": "objectives",
+          "refId": "A"
+        },
+        {
+          "expr": "agents_company_control_plane_work_items",
+          "legendFormat": "work items",
+          "refId": "B"
+        },
+        {
+          "expr": "agents_company_control_plane_runs",
+          "legendFormat": "runs",
+          "refId": "C"
+        },
+        {
+          "expr": "agents_company_control_plane_approvals",
+          "legendFormat": "approvals",
+          "refId": "D"
+        }
+      ],
+      "title": "Operator Workload",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["agents-company", "escalonalabs", "launch"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Agents Company Overview",
+  "version": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-company",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",
@@ -37,6 +37,7 @@
     "smoke:customer-foundations": "pnpm --filter @escalonalabs/control-plane exec tsx ../../scripts/smoke-customer-foundations.ts",
     "smoke:self-hosted": "pnpm --filter @escalonalabs/control-plane exec tsx ../../scripts/smoke-self-hosted.ts",
     "smoke:bootstrap": "pnpm db:migrate && pnpm db:seed && pnpm smoke:control-plane && pnpm smoke:memory",
+    "release:evidence": "pnpm exec tsx scripts/build-release-evidence.ts",
     "ops:backup:postgres": "bash scripts/ops/backup-postgres.sh",
     "ops:restore-drill:postgres": "bash scripts/ops/restore-drill-postgres.sh",
     "ops:drill:compose-recovery": "bash scripts/ops/drill-compose-recovery.sh",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalonalabs/domain",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/execution/package.json
+++ b/packages/execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalonalabs/execution",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalonalabs/github",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -3,6 +3,7 @@ export * from './drift';
 export * from './metadata';
 export * from './projections';
 export * from './reconciliation';
+export * from './releaseReadiness';
 export * from './sync';
 export * from './transport';
 export * from './types';

--- a/packages/github/src/releaseReadiness.test.ts
+++ b/packages/github/src/releaseReadiness.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ReleaseEvidenceInput,
+  evaluateReleaseReadiness,
+  summarizeRequiredChecks,
+} from './releaseReadiness';
+
+function createBaseInput(): ReleaseEvidenceInput {
+  return {
+    mainProtected: true,
+    releaseProtected: true,
+    requiredChecks: ['quality', 'replay-regression', 'self-hosted-smoke'],
+    observedChecks: [
+      { name: 'quality', status: 'completed', conclusion: 'success' },
+      {
+        name: 'replay-regression',
+        status: 'completed',
+        conclusion: 'success',
+      },
+      {
+        name: 'self-hosted-smoke',
+        status: 'completed',
+        conclusion: 'success',
+      },
+    ],
+    requiredDocs: [
+      'docs/operations/ga-runbook.md',
+      'docs/operations/release-train.md',
+      'docs/operations/support-and-oncall.md',
+      'docs/operations/hosted-aws.md',
+      'docs/operations/self-hosted.md',
+    ],
+    publishedDocs: [
+      'docs/operations/ga-runbook.md',
+      'docs/operations/release-train.md',
+      'docs/operations/support-and-oncall.md',
+      'docs/operations/hosted-aws.md',
+      'docs/operations/self-hosted.md',
+    ],
+    releaseBranch: 'release/v0.1.0',
+    tagName: 'v0.1.0',
+    releasePublished: true,
+    blockingIssues: [],
+  };
+}
+
+describe('release readiness helpers', () => {
+  it('marks the release ready when protections, checks, docs, and artifacts exist', () => {
+    const result = evaluateReleaseReadiness(createBaseInput());
+
+    expect(result.ready).toBe(true);
+    expect(result.blockingFindings).toEqual([]);
+    expect(result.checks.missing).toEqual([]);
+    expect(result.checks.failing).toEqual([]);
+  });
+
+  it('fails closed when protections, checks, docs, or release artifacts are missing', () => {
+    const result = evaluateReleaseReadiness({
+      ...createBaseInput(),
+      mainProtected: false,
+      observedChecks: [
+        { name: 'quality', status: 'completed', conclusion: 'failure' },
+        { name: 'replay-regression', status: 'in_progress', conclusion: null },
+      ],
+      publishedDocs: ['docs/operations/ga-runbook.md'],
+      releaseBranch: undefined,
+      tagName: undefined,
+      releasePublished: false,
+      blockingIssues: [
+        'AC-1501 Deliver M15 Production Infrastructure and Reliability',
+      ],
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.blockingFindings).toContain(
+      'Main branch protection is not active.',
+    );
+    expect(result.blockingFindings).toContain(
+      'Release branch protection is missing one or more required passing checks.',
+    );
+    expect(result.blockingFindings).toContain(
+      'Required operational documentation is incomplete.',
+    );
+    expect(result.blockingFindings).toContain(
+      'No release branch is recorded for this candidate.',
+    );
+    expect(result.blockingFindings).toContain(
+      'No release tag is published for this candidate.',
+    );
+    expect(result.blockingFindings).toContain(
+      'No GitHub release is published for this candidate.',
+    );
+    expect(result.blockingFindings).toContain(
+      'Blocking GitHub issues remain open.',
+    );
+    expect(result.checks.failing).toEqual(['quality']);
+    expect(result.checks.missing).toEqual([
+      'replay-regression',
+      'self-hosted-smoke',
+    ]);
+    expect(result.docs.missing).toEqual([
+      'docs/operations/release-train.md',
+      'docs/operations/support-and-oncall.md',
+      'docs/operations/hosted-aws.md',
+      'docs/operations/self-hosted.md',
+    ]);
+  });
+
+  it('summarizes required checks deterministically', () => {
+    expect(
+      summarizeRequiredChecks([
+        'replay-regression',
+        'quality',
+        'quality',
+        'bootstrap-smoke',
+      ]),
+    ).toEqual(['bootstrap-smoke', 'quality', 'replay-regression']);
+  });
+});

--- a/packages/github/src/releaseReadiness.ts
+++ b/packages/github/src/releaseReadiness.ts
@@ -1,0 +1,186 @@
+export type ReleaseCheckStatus = 'queued' | 'in_progress' | 'completed';
+
+export type ReleaseCheckConclusion =
+  | 'success'
+  | 'failure'
+  | 'neutral'
+  | 'cancelled'
+  | 'timed_out'
+  | 'action_required'
+  | null;
+
+export interface ReleaseCheckObservation {
+  name: string;
+  status: ReleaseCheckStatus;
+  conclusion: ReleaseCheckConclusion;
+}
+
+export interface ReleaseEvidenceInput {
+  mainProtected: boolean;
+  releaseProtected: boolean;
+  requiredChecks: string[];
+  observedChecks: ReleaseCheckObservation[];
+  requiredDocs: string[];
+  publishedDocs: string[];
+  releaseBranch?: string;
+  tagName?: string;
+  releasePublished: boolean;
+  blockingIssues: string[];
+}
+
+export interface ReleaseReadinessReport {
+  ready: boolean;
+  blockingFindings: string[];
+  checks: {
+    required: string[];
+    observed: string[];
+    missing: string[];
+    failing: string[];
+  };
+  docs: {
+    required: string[];
+    published: string[];
+    missing: string[];
+  };
+  release: {
+    branch?: string;
+    tagName?: string;
+    published: boolean;
+  };
+  blockingIssues: string[];
+}
+
+function normalize(value: string): string {
+  return value.trim();
+}
+
+function uniqueOrdered(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const rawValue of values) {
+    const value = normalize(rawValue);
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    result.push(value);
+  }
+
+  return result;
+}
+
+export function summarizeRequiredChecks(checks: string[]): string[] {
+  return [...uniqueOrdered(checks)].sort((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
+export function evaluateReleaseReadiness(
+  input: ReleaseEvidenceInput,
+): ReleaseReadinessReport {
+  const requiredChecks = uniqueOrdered(input.requiredChecks);
+  const requiredDocs = uniqueOrdered(input.requiredDocs);
+  const publishedDocs = uniqueOrdered(input.publishedDocs);
+
+  const observedByName = new Map<string, ReleaseCheckObservation>();
+  for (const check of input.observedChecks) {
+    const name = normalize(check.name);
+    if (!name || observedByName.has(name)) {
+      continue;
+    }
+    observedByName.set(name, {
+      ...check,
+      name,
+    });
+  }
+
+  const failingChecks = requiredChecks.filter((name) => {
+    const observed = observedByName.get(name);
+    if (!observed) {
+      return false;
+    }
+    return (
+      observed.status === 'completed' &&
+      observed.conclusion !== 'success' &&
+      observed.conclusion !== null
+    );
+  });
+
+  const missingChecks = requiredChecks.filter((name) => {
+    const observed = observedByName.get(name);
+    if (!observed) {
+      return true;
+    }
+    if (
+      observed.status === 'completed' &&
+      observed.conclusion !== null &&
+      observed.conclusion !== 'success'
+    ) {
+      return false;
+    }
+    return !(
+      observed.status === 'completed' && observed.conclusion === 'success'
+    );
+  });
+
+  const missingDocs = requiredDocs.filter(
+    (docPath) => !publishedDocs.includes(docPath),
+  );
+
+  const blockingFindings: string[] = [];
+
+  if (!input.mainProtected) {
+    blockingFindings.push('Main branch protection is not active.');
+  }
+
+  if (!input.releaseProtected || missingChecks.length > 0) {
+    blockingFindings.push(
+      'Release branch protection is missing one or more required passing checks.',
+    );
+  }
+
+  if (missingDocs.length > 0) {
+    blockingFindings.push('Required operational documentation is incomplete.');
+  }
+
+  if (!input.releaseBranch) {
+    blockingFindings.push('No release branch is recorded for this candidate.');
+  }
+
+  if (!input.tagName) {
+    blockingFindings.push('No release tag is published for this candidate.');
+  }
+
+  if (!input.releasePublished) {
+    blockingFindings.push('No GitHub release is published for this candidate.');
+  }
+
+  if (input.blockingIssues.length > 0) {
+    blockingFindings.push('Blocking GitHub issues remain open.');
+  }
+
+  return {
+    ready: blockingFindings.length === 0,
+    blockingFindings,
+    checks: {
+      required: requiredChecks,
+      observed: [...observedByName.keys()].sort((left, right) =>
+        left.localeCompare(right),
+      ),
+      missing: missingChecks,
+      failing: failingChecks,
+    },
+    docs: {
+      required: requiredDocs,
+      published: publishedDocs,
+      missing: missingDocs,
+    },
+    release: {
+      branch: input.releaseBranch,
+      tagName: input.tagName,
+      published: input.releasePublished,
+    },
+    blockingIssues: [...input.blockingIssues],
+  };
+}

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalonalabs/kernel",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalonalabs/memory",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalonalabs/orchestration",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalonalabs/sdk",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalonalabs/ui",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/scripts/build-release-evidence.ts
+++ b/scripts/build-release-evidence.ts
@@ -1,0 +1,563 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  type ReleaseCheckObservation,
+  evaluateReleaseReadiness,
+  summarizeRequiredChecks,
+} from '../packages/github/src/releaseReadiness';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const DEFAULT_REPO = 'escalonalabs/agents-company-escalona-labs';
+const MAIN_RULESET_NAME = 'Main Branch Protection';
+const RELEASE_RULESET_NAME = 'Release Candidate Protection';
+const REQUIRED_CHECKS = summarizeRequiredChecks([
+  'quality',
+  'ops-validation',
+  'bootstrap-smoke',
+  'integration-smokes',
+  'self-hosted-smoke',
+  'repo-guardrails',
+  'dependency-review',
+  'secret-scan',
+  'replay-regression',
+]);
+const MILESTONE_TITLES = [
+  'M15 Production Infrastructure and Reliability',
+  'M16 Internal Alpha and Controlled Beta',
+  'M17 General Availability',
+  'M18 Launch Evidence and Activation',
+];
+
+interface CliOptions {
+  repo: string;
+  semanticVersion: string;
+  tagName: string;
+  releaseBranch: string;
+  outputDir: string;
+  milestoneTitles: string[];
+}
+
+interface VersionAlignment {
+  expectedVersion: string;
+  packageVersions: Array<{ path: string; version: string }>;
+  chartVersion: string | null;
+  chartAppVersion: string | null;
+  stagingImageTags: string[];
+  productionImageTags: string[];
+  immutableEcrConfigured: boolean;
+  mismatches: string[];
+}
+
+interface ReleaseEvidenceFile {
+  generatedAt: string;
+  repo: string;
+  version: {
+    semanticVersion: string;
+    tagName: string;
+    releaseBranch: string;
+    commitSha?: string;
+  };
+  milestones: Array<{
+    title: string;
+    number?: number;
+    issues: Array<{ number: number; title: string; url: string }>;
+    missing: boolean;
+  }>;
+  readiness: ReturnType<typeof evaluateReleaseReadiness>;
+  versionAlignment: VersionAlignment;
+  release: {
+    published: boolean;
+    url?: string;
+    isDraft?: boolean;
+    isPrerelease?: boolean;
+  };
+}
+
+function parseCliArgs(argv: string[]): CliOptions {
+  const provided = new Map<string, string>();
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+
+    const inlineValueIndex = arg.indexOf('=');
+    if (inlineValueIndex > -1) {
+      provided.set(
+        arg.slice(2, inlineValueIndex),
+        arg.slice(inlineValueIndex + 1),
+      );
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (!next || next.startsWith('--')) {
+      provided.set(arg.slice(2), 'true');
+      continue;
+    }
+
+    provided.set(arg.slice(2), next);
+    index += 1;
+  }
+
+  const rawVersion = provided.get('version');
+  if (!rawVersion) {
+    throw new Error('--version is required. Example: --version v0.1.0');
+  }
+
+  const semanticVersion = rawVersion.startsWith('v')
+    ? rawVersion.slice(1)
+    : rawVersion;
+  const tagName = rawVersion.startsWith('v') ? rawVersion : `v${rawVersion}`;
+  const releaseBranch = provided.get('release-branch') ?? `release/${tagName}`;
+  const outputDir =
+    provided.get('output-dir') ??
+    join(REPO_ROOT, 'artifacts', 'releases', tagName);
+  const milestoneTitles = (
+    provided
+      .get('milestones')
+      ?.split(',')
+      .map((value) => value.trim()) ?? MILESTONE_TITLES
+  ).filter(Boolean);
+
+  return {
+    repo: provided.get('repo') ?? DEFAULT_REPO,
+    semanticVersion,
+    tagName,
+    releaseBranch,
+    outputDir,
+    milestoneTitles,
+  };
+}
+
+function runCommand(command: string, args: string[]): string {
+  return execFileSync(command, args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GH_PAGER: 'cat',
+    },
+  }).trim();
+}
+
+function tryRunJson(command: string, args: string[]) {
+  try {
+    const output = runCommand(command, args);
+    return output ? JSON.parse(output) : null;
+  } catch {
+    return null;
+  }
+}
+
+function fileExists(path: string) {
+  return existsSync(join(REPO_ROOT, path));
+}
+
+async function readJson(path: string) {
+  const raw = await readFile(join(REPO_ROOT, path), 'utf8');
+  return JSON.parse(raw) as { version?: string };
+}
+
+async function readChartVersions() {
+  const raw = await readFile(
+    join(REPO_ROOT, 'charts/agents-company/Chart.yaml'),
+    'utf8',
+  );
+
+  const chartVersion = raw.match(/^version:\s*([^\s]+)\s*$/m)?.[1] ?? null;
+  const chartAppVersion =
+    raw.match(/^appVersion:\s*"?(.*?)"?\s*$/m)?.[1] ?? null;
+
+  return {
+    chartVersion,
+    chartAppVersion,
+  };
+}
+
+async function readYamlImageTags(relativePath: string) {
+  const raw = await readFile(join(REPO_ROOT, relativePath), 'utf8');
+  return [...raw.matchAll(/^\s*tag:\s*([^\s]+)\s*$/gm)].map((match) =>
+    match[1]?.replace(/^"|"$/g, ''),
+  );
+}
+
+async function evaluateVersionAlignment(
+  semanticVersion: string,
+  tagName: string,
+): Promise<VersionAlignment> {
+  const packageJsonPaths = [
+    'package.json',
+    'apps/control-web/package.json',
+    'packages/domain/package.json',
+    'packages/execution/package.json',
+    'packages/github/package.json',
+    'packages/kernel/package.json',
+    'packages/memory/package.json',
+    'packages/orchestration/package.json',
+    'packages/sdk/package.json',
+    'packages/ui/package.json',
+    'server/control-plane/package.json',
+    'server/github-app/package.json',
+  ];
+
+  const packageVersions = await Promise.all(
+    packageJsonPaths.map(async (path) => ({
+      path,
+      version: (await readJson(path)).version ?? 'missing',
+    })),
+  );
+  const chartVersions = await readChartVersions();
+  const stagingImageTags = await readYamlImageTags(
+    'charts/agents-company/values-staging.yaml',
+  );
+  const productionImageTags = await readYamlImageTags(
+    'charts/agents-company/values-production.yaml',
+  );
+  const infraRaw = await readFile(join(REPO_ROOT, 'infra/aws/main.tf'), 'utf8');
+  const immutableMatches = infraRaw.match(
+    /image_tag_mutability\s*=\s*"IMMUTABLE"/g,
+  );
+  const mismatches: string[] = [];
+
+  for (const entry of packageVersions) {
+    if (entry.version !== semanticVersion) {
+      mismatches.push(
+        `${entry.path} version is ${entry.version}, expected ${semanticVersion}.`,
+      );
+    }
+  }
+
+  if (chartVersions.chartVersion !== semanticVersion) {
+    mismatches.push(
+      `charts/agents-company/Chart.yaml version is ${chartVersions.chartVersion}, expected ${semanticVersion}.`,
+    );
+  }
+
+  if (chartVersions.chartAppVersion !== semanticVersion) {
+    mismatches.push(
+      `charts/agents-company/Chart.yaml appVersion is ${chartVersions.chartAppVersion}, expected ${semanticVersion}.`,
+    );
+  }
+
+  if (stagingImageTags.some((value) => value !== tagName)) {
+    mismatches.push(
+      `charts/agents-company/values-staging.yaml must use immutable image tag ${tagName}.`,
+    );
+  }
+
+  if (productionImageTags.some((value) => value !== tagName)) {
+    mismatches.push(
+      `charts/agents-company/values-production.yaml must use immutable image tag ${tagName}.`,
+    );
+  }
+
+  if ((immutableMatches?.length ?? 0) < 3) {
+    mismatches.push(
+      'infra/aws/main.tf must configure every ECR repository with IMMUTABLE tags.',
+    );
+  }
+
+  return {
+    expectedVersion: semanticVersion,
+    packageVersions,
+    chartVersion: chartVersions.chartVersion,
+    chartAppVersion: chartVersions.chartAppVersion,
+    stagingImageTags,
+    productionImageTags,
+    immutableEcrConfigured: (immutableMatches?.length ?? 0) >= 3,
+    mismatches,
+  };
+}
+
+function readRulesets(repo: string) {
+  return (
+    (tryRunJson('gh', ['api', `repos/${repo}/rulesets`]) as Array<{
+      name?: string;
+      enforcement?: string;
+    }> | null) ?? []
+  );
+}
+
+function ruleActive(
+  rulesets: Array<{ name?: string; enforcement?: string }>,
+  targetName: string,
+) {
+  return rulesets.some(
+    (rule) => rule.name === targetName && rule.enforcement === 'active',
+  );
+}
+
+function readBranchHeadSha(repo: string, releaseBranch: string) {
+  const result = tryRunJson('gh', [
+    'api',
+    `repos/${repo}/branches/${releaseBranch}`,
+  ]) as { commit?: { sha?: string } } | null;
+
+  return result?.commit?.sha;
+}
+
+function readCheckRuns(
+  repo: string,
+  commitSha?: string,
+): ReleaseCheckObservation[] {
+  if (!commitSha) {
+    return [];
+  }
+
+  const result = tryRunJson('gh', [
+    'api',
+    `repos/${repo}/commits/${commitSha}/check-runs`,
+    '-H',
+    'Accept: application/vnd.github+json',
+  ]) as {
+    check_runs?: Array<{
+      name?: string;
+      status?: ReleaseCheckObservation['status'];
+      conclusion?: ReleaseCheckObservation['conclusion'];
+    }>;
+  } | null;
+
+  return (result?.check_runs ?? [])
+    .filter((item) => item.name)
+    .map((item) => ({
+      name: String(item.name),
+      status: item.status ?? 'queued',
+      conclusion: item.conclusion ?? null,
+    }));
+}
+
+function readMilestones(repo: string) {
+  return (
+    (tryRunJson('gh', [
+      'api',
+      `repos/${repo}/milestones?state=all&per_page=100`,
+    ]) as Array<{
+      title?: string;
+      number?: number;
+      state?: string;
+    }> | null) ?? []
+  );
+}
+
+function readOpenIssuesForMilestone(repo: string, milestoneNumber: number) {
+  return (
+    (tryRunJson('gh', [
+      'api',
+      `repos/${repo}/issues?state=open&milestone=${String(
+        milestoneNumber,
+      )}&per_page=100`,
+    ]) as Array<{
+      number?: number;
+      title?: string;
+      html_url?: string;
+      pull_request?: unknown;
+    }> | null) ?? []
+  );
+}
+
+function readRelease(repo: string, tagName: string) {
+  return tryRunJson('gh', [
+    'release',
+    'view',
+    tagName,
+    '--repo',
+    repo,
+    '--json',
+    'tagName,url,isDraft,isPrerelease',
+  ]) as {
+    tagName?: string;
+    url?: string;
+    isDraft?: boolean;
+    isPrerelease?: boolean;
+  } | null;
+}
+
+function readRemoteTag(repo: string, tagName: string) {
+  return tryRunJson('gh', ['api', `repos/${repo}/git/ref/tags/${tagName}`]);
+}
+
+function renderSummary(input: ReleaseEvidenceFile) {
+  const milestoneLines = input.milestones.map((milestone) => {
+    if (milestone.missing) {
+      return `- ${milestone.title}: missing milestone`;
+    }
+
+    if (milestone.issues.length === 0) {
+      return `- ${milestone.title}: clear`;
+    }
+
+    return `- ${milestone.title}: ${milestone.issues
+      .map((issue) => `#${issue.number} ${issue.title}`)
+      .join(', ')}`;
+  });
+
+  const mismatchLines =
+    input.versionAlignment.mismatches.length > 0
+      ? input.versionAlignment.mismatches.map((item) => `- ${item}`)
+      : ['- none'];
+
+  const findingLines =
+    input.readiness.blockingFindings.length > 0
+      ? input.readiness.blockingFindings.map((item) => `- ${item}`)
+      : ['- none'];
+
+  return [
+    `# Release Evidence ${input.version.tagName}`,
+    '',
+    `- Generated at: ${input.generatedAt}`,
+    `- Repo: \`${input.repo}\``,
+    `- Release branch: \`${input.version.releaseBranch}\``,
+    `- Commit: \`${input.version.commitSha ?? 'missing'}\``,
+    `- Ready: \`${String(
+      input.readiness.ready && input.versionAlignment.mismatches.length === 0,
+    )}\``,
+    '',
+    '## Blocking findings',
+    ...findingLines,
+    '',
+    '## Version alignment',
+    ...mismatchLines,
+    '',
+    '## Required checks',
+    `- Required: ${input.readiness.checks.required.join(', ')}`,
+    `- Missing: ${input.readiness.checks.missing.join(', ') || 'none'}`,
+    `- Failing: ${input.readiness.checks.failing.join(', ') || 'none'}`,
+    '',
+    '## Required docs',
+    `- Missing: ${input.readiness.docs.missing.join(', ') || 'none'}`,
+    '',
+    '## Milestones',
+    ...milestoneLines,
+    '',
+    '## Release state',
+    `- Remote tag present: \`${String(Boolean(input.readiness.release.tagName))}\``,
+    `- GitHub release published: \`${String(input.release.published)}\``,
+    `- Release URL: ${input.release.url ?? 'not published'}`,
+    `- Draft release: \`${String(input.release.isDraft ?? false)}\``,
+    `- Prerelease: \`${String(input.release.isPrerelease ?? false)}\``,
+    '',
+  ].join('\n');
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv.slice(2));
+  const releaseNotesPath = `docs/releases/${options.tagName}.md`;
+  const requiredDocs = [
+    'docs/operations/ga-runbook.md',
+    'docs/operations/release-train.md',
+    'docs/operations/support-and-oncall.md',
+    'docs/operations/hosted-aws.md',
+    'docs/operations/self-hosted.md',
+    'docs/operations/hosted-rotation-and-drills.md',
+    'docs/operations/monitoring-dashboards.md',
+    'ops/monitoring/grafana/agents-company-overview.json',
+    releaseNotesPath,
+  ];
+  const publishedDocs = requiredDocs.filter((path) => fileExists(path));
+  const rulesets = readRulesets(options.repo);
+  const mainProtected = ruleActive(rulesets, MAIN_RULESET_NAME);
+  const releaseProtected = ruleActive(rulesets, RELEASE_RULESET_NAME);
+  const commitSha = readBranchHeadSha(options.repo, options.releaseBranch);
+  const observedChecks = readCheckRuns(options.repo, commitSha);
+  const releaseInfo = readRelease(options.repo, options.tagName);
+  const tagExists = Boolean(readRemoteTag(options.repo, options.tagName));
+  const allMilestones = readMilestones(options.repo);
+
+  const milestoneReports = options.milestoneTitles.map((title) => {
+    const milestone = allMilestones.find((item) => item.title === title);
+    if (!milestone?.number) {
+      return {
+        title,
+        missing: true,
+        issues: [],
+      };
+    }
+
+    const issues = readOpenIssuesForMilestone(options.repo, milestone.number)
+      .filter((item) => !item.pull_request)
+      .map((item) => ({
+        number: item.number ?? 0,
+        title: item.title ?? 'Untitled issue',
+        url: item.html_url ?? '',
+      }));
+
+    return {
+      title,
+      number: milestone.number,
+      missing: false,
+      issues,
+    };
+  });
+
+  const blockingIssues = milestoneReports.flatMap((milestone) => {
+    if (milestone.missing) {
+      return [`Missing GitHub milestone: ${milestone.title}`];
+    }
+
+    return milestone.issues.map((issue) => `#${issue.number} ${issue.title}`);
+  });
+
+  const readiness = evaluateReleaseReadiness({
+    mainProtected,
+    releaseProtected,
+    requiredChecks: REQUIRED_CHECKS,
+    observedChecks,
+    requiredDocs,
+    publishedDocs,
+    releaseBranch: commitSha ? options.releaseBranch : undefined,
+    tagName: tagExists ? options.tagName : undefined,
+    releasePublished: Boolean(releaseInfo && !releaseInfo.isDraft),
+    blockingIssues,
+  });
+  const versionAlignment = await evaluateVersionAlignment(
+    options.semanticVersion,
+    options.tagName,
+  );
+  const evidence: ReleaseEvidenceFile = {
+    generatedAt: new Date().toISOString(),
+    repo: options.repo,
+    version: {
+      semanticVersion: options.semanticVersion,
+      tagName: options.tagName,
+      releaseBranch: options.releaseBranch,
+      commitSha,
+    },
+    milestones: milestoneReports,
+    readiness,
+    versionAlignment,
+    release: {
+      published: Boolean(releaseInfo && !releaseInfo.isDraft),
+      url: releaseInfo?.url,
+      isDraft: releaseInfo?.isDraft,
+      isPrerelease: releaseInfo?.isPrerelease,
+    },
+  };
+  const summary = renderSummary(evidence);
+
+  await mkdir(options.outputDir, { recursive: true });
+  await writeFile(
+    join(options.outputDir, 'readiness.json'),
+    `${JSON.stringify(evidence, null, 2)}\n`,
+    'utf8',
+  );
+  await writeFile(
+    join(options.outputDir, 'SUMMARY.md'),
+    `${summary}\n`,
+    'utf8',
+  );
+
+  process.stdout.write(`${summary}\n`);
+
+  if (!readiness.ready || versionAlignment.mismatches.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/server/control-plane/package.json
+++ b/server/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalonalabs/control-plane",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/server/github-app/package.json
+++ b/server/github-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalonalabs/github-app",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary
- add fail-closed release readiness helpers and evidence generation tooling
- ship immutable version/tag alignment for the v0.1.0 candidate
- publish M18 docs, monitoring dashboard assets, and hosted rotation or drill procedures

## Validation
- pnpm run ci
- pnpm ops:validate:m15
- python3 .github/scripts/bootstrap_github.py --repo escalonalabs/agents-company-escalona-labs --apply --sync-milestones --sync-issues