### PR TITLE
Add hosted deploy workflow and remote Terraform state

### DIFF
--- a/.github/workflows/hosted-deploy.yml
+++ b/.github/workflows/hosted-deploy.yml
@@ -1,0 +1,372 @@
+name: hosted-deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Hosted target environment"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      version:
+        description: "Immutable release version or tag. Example: v0.1.0"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to deploy. Defaults to refs/tags/<version> when empty."
+        required: false
+        type: string
+      apply_infra:
+        description: "Apply Terraform before building and deploying"
+        required: false
+        default: true
+        type: boolean
+      verify_public_url:
+        description: "Verify the public environment URL after rollout"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve checkout ref
+        id: meta
+        shell: bash
+        run: |
+          VERSION_INPUT="${{ inputs.version }}"
+          if [[ "$VERSION_INPUT" != v* ]]; then
+            VERSION_TAG="v$VERSION_INPUT"
+          else
+            VERSION_TAG="$VERSION_INPUT"
+          fi
+
+          REF_INPUT="${{ inputs.ref }}"
+          if [[ -n "$REF_INPUT" ]]; then
+            CHECKOUT_REF="$REF_INPUT"
+          else
+            CHECKOUT_REF="$VERSION_TAG"
+          fi
+
+          echo "version_tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.meta.outputs.checkout_ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate hosted readiness assets
+        run: |
+          pnpm ops:validate:m15
+          pnpm release:evidence -- --version "${{ steps.meta.outputs.version_tag }}" --release-branch "release/${{ steps.meta.outputs.version_tag }}"
+
+  deploy:
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    env:
+      DEPLOY_ENV: ${{ inputs.environment }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      KUBERNETES_NAMESPACE: ${{ vars.KUBERNETES_NAMESPACE }}
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+      TF_VARS: ${{ secrets.TF_VARS }}
+      TF_BACKEND_BUCKET: ${{ secrets.TF_BACKEND_BUCKET }}
+      TF_BACKEND_KEY: ${{ secrets.TF_BACKEND_KEY }}
+      TF_BACKEND_DYNAMODB_TABLE: ${{ secrets.TF_BACKEND_DYNAMODB_TABLE }}
+    steps:
+      - name: Resolve deploy metadata
+        id: meta
+        shell: bash
+        run: |
+          VERSION_INPUT="${{ inputs.version }}"
+          if [[ "$VERSION_INPUT" != v* ]]; then
+            VERSION_TAG="v$VERSION_INPUT"
+          else
+            VERSION_TAG="$VERSION_INPUT"
+          fi
+
+          REF_INPUT="${{ inputs.ref }}"
+          if [[ -n "$REF_INPUT" ]]; then
+            CHECKOUT_REF="$REF_INPUT"
+          else
+            CHECKOUT_REF="$VERSION_TAG"
+          fi
+
+          case "${{ inputs.environment }}" in
+            production)
+              DEFAULT_URL="https://agents-company.escalonalabs.com"
+              ;;
+            staging)
+              DEFAULT_URL="https://staging.agents-company.escalonalabs.com"
+              ;;
+            *)
+              echo "Unsupported environment '${{ inputs.environment }}'." >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ -n "${KUBERNETES_NAMESPACE:-}" ]]; then
+            TARGET_NAMESPACE="$KUBERNETES_NAMESPACE"
+          else
+            TARGET_NAMESPACE="agents-company-${{ inputs.environment }}"
+          fi
+
+          echo "version_tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
+          echo "target_namespace=$TARGET_NAMESPACE" >> "$GITHUB_OUTPUT"
+          echo "public_url=$DEFAULT_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Verify environment configuration
+        shell: bash
+        run: |
+          missing=()
+          [[ -n "${AWS_ROLE_TO_ASSUME:-}" ]] || missing+=("AWS_ROLE_TO_ASSUME")
+          [[ -n "${AWS_REGION:-}" ]] || missing+=("AWS_REGION")
+          [[ -n "${TF_VARS:-}" ]] || missing+=("TF_VARS")
+          [[ -n "${TF_BACKEND_BUCKET:-}" ]] || missing+=("TF_BACKEND_BUCKET")
+          [[ -n "${TF_BACKEND_KEY:-}" ]] || missing+=("TF_BACKEND_KEY")
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required environment configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.meta.outputs.checkout_ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          role-session-name: hosted-deploy-${{ github.run_id }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.12.2
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.17.3
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.33.0
+
+      - name: Write Terraform variables file
+        shell: bash
+        run: |
+          cat <<'EOF' > "$RUNNER_TEMP/terraform.tfvars"
+          ${{ env.TF_VARS }}
+          EOF
+
+      - name: Terraform init
+        shell: bash
+        run: |
+          init_args=(
+            -chdir=infra/aws
+            init
+            -input=false
+            -backend-config="bucket=${TF_BACKEND_BUCKET}"
+            -backend-config="key=${TF_BACKEND_KEY}"
+            -backend-config="region=${AWS_REGION}"
+            -backend-config="encrypt=true"
+          )
+
+          if [[ -n "${TF_BACKEND_DYNAMODB_TABLE:-}" ]]; then
+            init_args+=(-backend-config="dynamodb_table=${TF_BACKEND_DYNAMODB_TABLE}")
+          fi
+
+          terraform "${init_args[@]}"
+
+      - name: Terraform plan
+        shell: bash
+        run: |
+          terraform -chdir=infra/aws plan \
+            -input=false \
+            -var-file="$RUNNER_TEMP/terraform.tfvars" \
+            -out="$RUNNER_TEMP/terraform.plan"
+
+      - name: Terraform apply
+        if: ${{ inputs.apply_infra }}
+        shell: bash
+        run: |
+          terraform -chdir=infra/aws apply -input=false -auto-approve "$RUNNER_TEMP/terraform.plan"
+
+      - name: Capture Terraform outputs
+        id: tf_outputs
+        shell: bash
+        run: |
+          terraform -chdir=infra/aws output -json > "$RUNNER_TEMP/terraform-outputs.json"
+
+          CONTROL_PLANE_REPO="$(jq -r '.ecr_repositories.value.control_plane' "$RUNNER_TEMP/terraform-outputs.json")"
+          GITHUB_APP_REPO="$(jq -r '.ecr_repositories.value.github_app' "$RUNNER_TEMP/terraform-outputs.json")"
+          CONTROL_WEB_REPO="$(jq -r '.ecr_repositories.value.control_web' "$RUNNER_TEMP/terraform-outputs.json")"
+          CLUSTER_NAME="$(jq -r '.cluster_name.value' "$RUNNER_TEMP/terraform-outputs.json")"
+          RUNTIME_IRSA_ROLE_ARN="$(jq -r '.runtime_irsa_role_arn.value' "$RUNNER_TEMP/terraform-outputs.json")"
+          RUNTIME_SECRET_NAME="$(jq -r '.helm_runtime_secret_name.value' "$RUNNER_TEMP/terraform-outputs.json")"
+          RUNTIME_SECRET_REMOTE_KEY="$(jq -r '.helm_values_hint.value.runtime_secret_remote_key' "$RUNNER_TEMP/terraform-outputs.json")"
+
+          {
+            echo "control_plane_repo=$CONTROL_PLANE_REPO"
+            echo "github_app_repo=$GITHUB_APP_REPO"
+            echo "control_web_repo=$CONTROL_WEB_REPO"
+            echo "cluster_name=$CLUSTER_NAME"
+            echo "runtime_irsa_role_arn=$RUNTIME_IRSA_ROLE_ARN"
+            echo "runtime_secret_name=$RUNTIME_SECRET_NAME"
+            echo "runtime_secret_remote_key=$RUNTIME_SECRET_REMOTE_KEY"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push control-plane
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.control-plane
+          push: true
+          tags: ${{ steps.tf_outputs.outputs.control_plane_repo }}:${{ steps.meta.outputs.version_tag }}
+
+      - name: Build and push github-app
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.github-app
+          push: true
+          tags: ${{ steps.tf_outputs.outputs.github_app_repo }}:${{ steps.meta.outputs.version_tag }}
+
+      - name: Build and push control-web
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.control-web
+          push: true
+          tags: ${{ steps.tf_outputs.outputs.control_web_repo }}:${{ steps.meta.outputs.version_tag }}
+
+      - name: Update kubeconfig
+        shell: bash
+        run: |
+          aws eks update-kubeconfig \
+            --name "${{ steps.tf_outputs.outputs.cluster_name }}" \
+            --region "$AWS_REGION"
+
+      - name: Verify cluster prerequisites
+        shell: bash
+        run: |
+          kubectl get crd externalsecrets.external-secrets.io
+          kubectl get clustersecretstore aws-secretsmanager
+          aws secretsmanager describe-secret --secret-id "${{ steps.tf_outputs.outputs.runtime_secret_remote_key }}" >/dev/null
+
+      - name: Render hosted overrides
+        shell: bash
+        run: |
+          cat <<EOF > "$RUNNER_TEMP/hosted-overrides.yaml"
+          runtimeSecret:
+            existingSecretName: ${{ steps.tf_outputs.outputs.runtime_secret_name }}
+            externalSecret:
+              remoteSecretKey: ${{ steps.tf_outputs.outputs.runtime_secret_remote_key }}
+          controlPlane:
+            image:
+              repository: ${{ steps.tf_outputs.outputs.control_plane_repo }}
+              tag: ${{ steps.meta.outputs.version_tag }}
+            serviceAccount:
+              annotations:
+                eks.amazonaws.com/role-arn: ${{ steps.tf_outputs.outputs.runtime_irsa_role_arn }}
+          githubApp:
+            image:
+              repository: ${{ steps.tf_outputs.outputs.github_app_repo }}
+              tag: ${{ steps.meta.outputs.version_tag }}
+            serviceAccount:
+              annotations:
+                eks.amazonaws.com/role-arn: ${{ steps.tf_outputs.outputs.runtime_irsa_role_arn }}
+          controlWeb:
+            image:
+              repository: ${{ steps.tf_outputs.outputs.control_web_repo }}
+              tag: ${{ steps.meta.outputs.version_tag }}
+          EOF
+
+      - name: Deploy Helm release
+        shell: bash
+        run: |
+          helm upgrade --install agents-company ./charts/agents-company \
+            --namespace "${{ steps.meta.outputs.target_namespace }}" \
+            --create-namespace \
+            -f "./charts/agents-company/values-${{ inputs.environment }}.yaml" \
+            -f "$RUNNER_TEMP/hosted-overrides.yaml" \
+            --wait \
+            --timeout 15m
+
+      - name: Verify rollout state
+        shell: bash
+        run: |
+          kubectl rollout status deployment/agents-company-control-plane -n "${{ steps.meta.outputs.target_namespace }}" --timeout=10m
+          kubectl rollout status deployment/agents-company-github-app -n "${{ steps.meta.outputs.target_namespace }}" --timeout=10m
+          kubectl rollout status deployment/agents-company-control-web -n "${{ steps.meta.outputs.target_namespace }}" --timeout=10m
+
+      - name: Verify public endpoint
+        if: ${{ inputs.verify_public_url }}
+        shell: bash
+        run: |
+          curl --fail --show-error --silent \
+            --retry 12 \
+            --retry-delay 10 \
+            "${{ steps.meta.outputs.public_url }}/web-health"
+
+      - name: Publish deployment summary
+        shell: bash
+        run: |
+          {
+            echo "## Hosted Deploy"
+            echo ""
+            echo "- Environment: ${{ inputs.environment }}"
+            echo "- Version: ${{ steps.meta.outputs.version_tag }}"
+            echo "- Ref: ${{ steps.meta.outputs.checkout_ref }}"
+            echo "- Namespace: ${{ steps.meta.outputs.target_namespace }}"
+            echo "- Cluster: ${{ steps.tf_outputs.outputs.cluster_name }}"
+            echo "- Public URL: ${{ steps.meta.outputs.public_url }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/operations/ga-runbook.md
+++ b/docs/operations/ga-runbook.md
@@ -39,10 +39,10 @@ Confirm the following operational assets are healthy:
 
 1. Cut or update the target `release/*` branch.
 2. Confirm every required check is green.
-3. Deploy to staging and run operator smoke tests.
+3. Dispatch `.github/workflows/hosted-deploy.yml` to `staging` and run operator smoke tests.
 4. Confirm webhook delivery and artifact flow in staging.
 5. Review rollback target and launch ownership.
-6. Deploy the same candidate to production.
+6. Promote the same candidate through `.github/workflows/hosted-deploy.yml` to `production`.
 7. Tag the production commit and publish release notes.
 
 ## Immediate post-launch watch

--- a/docs/operations/hosted-aws.md
+++ b/docs/operations/hosted-aws.md
@@ -50,6 +50,50 @@ values together before rollout.
    it differs from the examples.
 6. Deploy the Helm chart into the target namespace.
 
+## GitHub Actions deployment path
+
+The repository now ships a manual hosted deployment workflow:
+
+- [`.github/workflows/hosted-deploy.yml`](../../.github/workflows/hosted-deploy.yml)
+
+Use one GitHub environment per hosted target:
+
+- `staging`
+- `production`
+
+Configure these values on each environment before dispatching the workflow:
+
+| Name | Type | Purpose |
+| --- | --- | --- |
+| `AWS_ROLE_TO_ASSUME` | secret | IAM role assumed through GitHub OIDC for Terraform, ECR, EKS, and Secrets Manager access |
+| `TF_VARS` | secret | Full multiline contents of the target `tfvars` file |
+| `TF_BACKEND_BUCKET` | secret | S3 bucket used for Terraform remote state |
+| `TF_BACKEND_KEY` | secret | Object key for the environment Terraform state |
+| `TF_BACKEND_DYNAMODB_TABLE` | secret, optional | DynamoDB table for Terraform state locking |
+| `AWS_REGION` | variable | AWS region for the environment |
+| `KUBERNETES_NAMESPACE` | variable, optional | Helm target namespace, defaults to `agents-company-<environment>` |
+
+The workflow performs this sequence:
+
+1. Validate the repository and hosted assets.
+2. Assume the environment IAM role through OIDC.
+3. Initialize Terraform with the remote backend and apply the target `tfvars`.
+4. Read Terraform outputs for the ECR repositories, cluster, and runtime secret.
+5. Build and push the three immutable release images to ECR.
+6. Update the EKS kubeconfig, verify `ExternalSecret` prerequisites, and run
+   `helm upgrade --install`.
+7. Wait for the three runtime deployments to become ready and verify the public
+   health endpoint.
+
+Dispatch example:
+
+```text
+workflow: hosted-deploy
+environment: production
+version: v0.1.0
+ref: release/v0.1.0
+```
+
 ## GitHub webhook path
 
 Hosted ingress is intentionally single-origin through `control-web`.
@@ -105,11 +149,12 @@ actual AWS account, EKS cluster, and GitHub App installation.
 This repository now validates the infrastructure contract and deployment assets,
 but it cannot prove hosted production is live without:
 
-- AWS credentials
-- an actual EKS cluster
+- environment-level GitHub secrets and variables for the deploy workflow
+- an AWS account reachable through the configured OIDC role
+- a real EKS cluster
 - External Secrets Operator installed
 - a real GitHub App installation
-- pushed images in the target ECR repositories
+- successful image pushes into the target ECR repositories
 
 So `M15` can be repo-ready and operationally rehearsable here, but final hosted
 go-live still depends on those environment-specific steps.

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -19,6 +19,8 @@ This directory contains the versioned hosted deployment scaffold for
 
 - Existing VPC and subnets
 - AWS credentials with permission to create the resources above
+- Existing S3 bucket for Terraform remote state
+- Optional DynamoDB table for Terraform state locking
 - External Secrets Operator installed in the target EKS cluster
 - A `ClusterSecretStore` or `SecretStore` that can read the runtime secret from
   AWS Secrets Manager
@@ -66,10 +68,19 @@ That command uses a Dockerized Terraform toolchain to run:
 cp infra/aws/staging.tfvars.example /tmp/agents-company-staging.tfvars
 # fill in real VPC ids, subnet ids, secrets, and GitHub App values
 
-terraform -chdir=infra/aws init
+terraform -chdir=infra/aws init \
+  -backend-config="bucket=<existing-terraform-state-bucket>" \
+  -backend-config="key=agents-company/staging.tfstate" \
+  -backend-config="region=us-east-1" \
+  -backend-config="encrypt=true" \
+  -backend-config="dynamodb_table=<optional-lock-table>"
 terraform -chdir=infra/aws plan -var-file=/tmp/agents-company-staging.tfvars
 terraform -chdir=infra/aws apply -var-file=/tmp/agents-company-staging.tfvars
 ```
+
+The hosted GitHub Actions workflow uses the same backend inputs through the
+environment secrets `TF_BACKEND_BUCKET`, `TF_BACKEND_KEY`, and the optional
+`TF_BACKEND_DYNAMODB_TABLE`.
 
 ## Important outputs
 

--- a/infra/aws/versions.tf
+++ b/infra/aws/versions.tf
@@ -1,6 +1,8 @@
 terraform {
   required_version = ">= 1.8.0"
 
+  backend "s3" {}
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## Summary
- add a manual hosted deploy workflow for staging and production
- switch the AWS Terraform scaffold to an S3 remote backend contract
- document the GitHub environment secrets, variables, and deploy flow

## Validation
- pnpm ops:validate:m15
- python3 YAML parse for .github/workflows/hosted-deploy.yml
- gh api repos/escalonalabs/agents-company-escalona-labs/environments